### PR TITLE
improve ocropy processor

### DIFF
--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -56,6 +56,16 @@
 			],
 			"description": "Recognize text in lines with ocropy",
 			"parameters": {
+                                "dewarping": {
+                                    "type": "boolean",
+                                    "description": "enable line normalization",
+                                    "default": true
+                                },
+                                "binarization": {
+                                    "type": "string",
+                                    "enum": ["none", "global", "otsu", "gauss-otsu", "ocropy"],
+                                    "default": "none"
+                                },
 				"textequiv_level": {
 					"type": "string",
 					"enum": ["line", "word", "glyph"],

--- a/ocrd_cis/ocropy/ocrolib/common.py
+++ b/ocrd_cis/ocropy/ocrolib/common.py
@@ -139,7 +139,7 @@ def array2pil(a):
         else:
             raise OcropusException("bad image rank")
     elif a.dtype==dtype('float32'):
-        return PIL.Image.fromstring("F",(a.shape[1],a.shape[0]),a.tostring())
+        return PIL.Image.frombytes("F",(a.shape[1],a.shape[0]),a.tostring())
     else:
         raise OcropusException("unknown image type")
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'ocrd>=1.0.0b5',
         'click',
         'scipy',
-        'matplotlib',
+        'pillow==5.4.1',
+        'matplotlib>3.0.0',
         'python-Levenshtein',
         'calamari_ocr'
     ],


### PR DESCRIPTION
I tried applying your Python 3 port / workspace processor of ocropy, but the results were really bad on [OCR-D GT](https://ocr-d-repo.scc.kit.edu/api/v1/metastore/bagit). (I always use `OCR-D-GT-SEG-LINE` on different models, like `LatinHist-98000.pyrnn.gz` from [chreul](https://github.com/chreul/OCR_Testdata_EarlyPrintedBooks), `incunabula-00184000.pyrnn.gz` from [GT4HistOCR](https://zenodo.org/record/1344132) or `fraktur-jze.pyrnn.gz` from [jze](https://github.com/jze/ocropus-model_fraktur). Those models are reported to achieve CER < 10%, and I can reproduce that when applying them on the test files in GT4HistOCR, which are deskewed, cropped and binarized / flattened properly. But I get CER >> 10% when applying them on our GT with your processor.)

By investigating, I found that many models expect **dewarping** to be _disabled_, so I added this option to the processor. Also, the GT data are still raw, so I re-enabled **binarization** and made the actual method selectable. I got best results when I added the full binarization from `ocropus-nlbin`, which also includes **deskewing**. Now the line images extracted from preprocessing look a lot more like the data in GT4HistOCR (although the threshold parameters could be optimised a bit). Recognition results are also much better than before, but I _still_ do not get CER < 10%. 

The most prominent difference of our line images is that large segments of the neighbouring lines still appear, so I guess one needs to **re-crop** after deskewing (but I don't know how to do that). But it might also be that the GT segmentation is the culprit (it seems to be off vertically).

Other improvements here are: error handling, ocropy sanity checks, no temporary files and CER calculation. 

I hope you find these useful. Please let me know if you require further changes or splitting into smaller commits. Also, I would be happy to share my measurements and sample images.

review requested – @finkf @wrznr @kba ?