### PR TITLE
separate preprocessing steps and use AlternativeImage in ocropy wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,31 @@ ocrd-cis-ocropy-train \
   --parameter file:///path/to/config.json
 ```
 
+### ocrd-cis-ocropy-clip
+The ocropy-clip tool can be used to remove intrusions of neighbouring segments in regions / lines of a workspace.
+It runs a (ad-hoc binarization and) connected component analysis on every text region / line of every PAGE in the input file group, as well as its overlapping neighbours, and for each binary object of conflict, determines whether it belongs to the neighbour, and can therefore be clipped to white. It references the resulting segment image files in the output PAGE (as AlternativeImage).
+```sh
+ocrd-cis-ocropy-clip \
+  --input-file-grp OCR-D-SEG-LINE \
+  --output-file-grp OCR-D-SEG-LINE-CLIP \
+  --mets mets.xml
+  --parameter file:///path/to/config.json
+```
+
+### ocrd-cis-ocropy-resegment
+The ocropy-resegment tool can be used to remove overlap between lines of a workspace.
+It runs a (ad-hoc binarization and) line segmentation on every text region of every PAGE in the input file group, and for each line already annotated, determines the label of largest extent within the original coordinates (polygon outline) in that line, and annotates the resulting coordinates in the output PAGE.
+```sh
+ocrd-cis-ocropy-resegment \
+  --input-file-grp OCR-D-SEG-LINE \
+  --output-file-grp OCR-D-SEG-LINE-RES \
+  --mets mets.xml
+  --parameter file:///path/to/config.json
+```
+
 ### ocrd-cis-ocropy-deskew
 The ocropy-deskew tool can be used to deskew regions of a workspace.
-It runs the Ocropy thresholding and deskewing estimation on every text region of every PAGE in the input file group and annotated the orientation angle in the output PAGE.
+It runs the Ocropy thresholding and deskewing estimation on every text region of every PAGE in the input file group and annotates the orientation angle in the output PAGE.
 ```sh
 ocrd-cis-ocropy-deskew \
   --input-file-grp OCR-D-SEG-LINE \
@@ -95,7 +117,7 @@ The ocropy-binarize tool can be used to grayscale-normalize and deskew pages / r
 It runs the Ocropy thresholding and deskewing estimation on every segment of every PAGE in the input file group and references the resulting segment image files in the output PAGE (as AlternativeImage). (If a deskewing angle has already been annotated in a region, the tool respects that and rotates accordingly.)
 ```sh
 ocrd-cis-ocropy-binarize \
-  --input-file-grp OCR-D-SEG-LINE \
+  --input-file-grp OCR-D-SEG-LINE-DES \
   --output-file-grp OCR-D-SEG-LINE-BIN \
   --mets mets.xml
   --parameter file:///path/to/config.json
@@ -153,7 +175,24 @@ place them into: /usr/share/tesseract-ocr/4.00/tessdata
 Tesserocr v2.4.0 seems broken for tesseract 4.0.0-beta. Install
 Version v2.3.1 instead: `pip install tesseract==2.3.1`.
 
+## Workflow configuration
 
+A decent pipeline might look like this:
+
+1. page-level cropping
+2. page-level binarization
+3. page-level deskewing
+4. page-level dewarping
+5. region segmentation
+6. region-level clipping
+7. region-level deskewing
+8. line segmentation
+9. line-level clipping or resegmentation
+10. line-level dewarping
+11. line-level recognition
+12. line-level alignment
+
+If GT is used, steps 1, 5 and 8 can be omitted. Else if a segmentation is used in 5 and 8 which does not produce overlapping sections, steps 6 and 9 can be omitted.
 
 ## OCR-D links
 

--- a/README.md
+++ b/README.md
@@ -69,23 +69,56 @@ ocrd-cis-align \
 
 
 ### ocrd-cis-ocropy-train
-The ocropy-train tool can be used to train lstm models.
-The tool takes the ground truth from a workspace and safes the snippets from the corresponding page.
-Then the model is trained on all snippets for 1 million randomized iterations or the given number from the parameter file.
+The ocropy-train tool can be used to train LSTM models.
+It takes ground truth from the workspace and saves (image+text) snippets from the corresponding pages.
+Then a model is trained on all snippets for 1 million (or the given number of) randomized iterations from the parameter file.
 ```sh
 ocrd-cis-ocropy-train \
-  --input-file-grp 'OCR-D-XML' \
+  --input-file-grp OCR-D-GT-SEG-LINE \
+  --mets mets.xml
+  --parameter file:///path/to/config.json
+```
+
+### ocrd-cis-ocropy-deskew
+The ocropy-deskew tool can be used to deskew regions of a workspace.
+It runs the Ocropy thresholding and deskewing estimation on every text region of every PAGE in the input file group and annotated the orientation angle in the output PAGE.
+```sh
+ocrd-cis-ocropy-deskew \
+  --input-file-grp OCR-D-SEG-LINE \
+  --output-file-grp OCR-D-SEG-LINE-DES \
+  --mets mets.xml
+  --parameter file:///path/to/config.json
+```
+
+### ocrd-cis-ocropy-binarize
+The ocropy-binarize tool can be used to grayscale-normalize and deskew pages / regions / lines of a workspace.
+It runs the Ocropy thresholding and deskewing estimation on every segment of every PAGE in the input file group and references the resulting segment image files in the output PAGE (as AlternativeImage). (If a deskewing angle has already been annotated in a region, the tool respects that and rotates accordingly.)
+```sh
+ocrd-cis-ocropy-binarize \
+  --input-file-grp OCR-D-SEG-LINE \
+  --output-file-grp OCR-D-SEG-LINE-BIN \
+  --mets mets.xml
+  --parameter file:///path/to/config.json
+```
+
+### ocrd-cis-ocropy-dewarp
+The ocropy-dewarp tool can be used to dewarp text lines of a workspace.
+It runs the Ocropy baseline estimation and dewarping on every line in every text region of every PAGE in the input file group and references the resulting line image files in the output PAGE (as AlternativeImage).
+```sh
+ocrd-cis-ocropy-dewarp \
+  --input-file-grp OCR-D-SEG-LINE-BIN \
+  --output-file-grp OCR-D-SEG-LINE-DEW \
   --mets mets.xml
   --parameter file:///path/to/config.json
 ```
 
 ### ocrd-cis-ocropy-recognize
 The ocropy-recognize tool can be used to recognize lines / words / glyphs from pages of a workspace.
-The tool runs the ocropy optical character recognition for each "region" given in the XML file of the workspace.
+It runs the Ocropy optical character recognition on every line in every text region of every PAGE in the input file group and adds the resulting text annotation in the output PAGE.
 ```sh
 ocrd-cis-ocropy-recognize \
-  --input-file-grp 'OCR-D-XML' \
-  --output-file-grp 'OCR-D-OCROPY' \
+  --input-file-grp OCR-D-SEG-LINE-DEW \
+  --output-file-grp OCR-D-OCR-OCRO \
   --mets mets.xml
   --parameter file:///path/to/config.json
 ```

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -46,6 +46,100 @@
 				}
 			}
 		},
+		"ocrd-cis-ocropy-binarize": {
+			"executable": "ocrd-cis-ocropy-binarize",
+			"categories": [
+				"Text recognition and optimization"
+			],
+			"steps": [
+				"preprocessing/optimization/binarization",
+				"preprocessing/optimization/grayscale_normalization",
+				"preprocessing/optimization/deskewing"
+			],
+			"input_file_grp": [
+				"OCR-D-IMG",
+				"OCR-D-SEG-BLOCK",
+				"OCR-D-SEG-LINE"
+			],
+			"output_file_grp": [
+				"OCR-D-IMG-BIN",
+				"OCR-D-SEG-BLOCK",
+				"OCR-D-SEG-LINE"
+			],
+			"description": "Binarize and deskew pages / regions / lines with ocropy",
+			"parameters": {
+				"method": {
+					"type": "string",
+					"enum": ["none", "global", "otsu", "gauss-otsu", "ocropy"],
+					"description": "binarization method to use (only ocropy will include deskewing)",
+					"default": "ocropy"
+				},
+				"maxskew": {
+					"type": "number",
+					"description": "modulus of maximum skewing angle to detect (larger will be slower, 0 will deactivate deskewing)",
+					"default": 5.0
+				},
+				"noise_maxsize": {
+					"type": "number",
+					"description": "maximum pixel number for connected components to regard as noise (0 will deactivate denoising)",
+					"default": 2
+				},
+				"level-of-operation": {
+					"type": "string",
+					"enum": ["page", "region", "line"],
+					"description": "PAGE XML hierarchy level granularity to annotate images for",
+					"default": "page"
+				}
+			}
+		},
+		"ocrd-cis-ocropy-deskew": {
+			"executable": "ocrd-cis-ocropy-deskew",
+			"categories": [
+				"Text recognition and optimization"
+			],
+			"steps": [
+				"preprocessing/optimization/deskewing"
+			],
+			"input_file_grp": [
+				"OCR-D-SEG-BLOCK",
+				"OCR-D-SEG-LINE"
+			],
+			"output_file_grp": [
+				"OCR-D-SEG-BLOCK",
+				"OCR-D-SEG-LINE"
+			],
+			"description": "Deskew regions with ocropy (but only by annotating orientation angle)",
+			"parameters": {
+				"maxskew": {
+					"type": "number",
+					"description": "modulus of maximum skewing angle to detect (larger will be slower, 0 will deactivate deskewing)",
+					"default": 5.0
+				}
+			}
+		},
+		"ocrd-cis-ocropy-dewarp": {
+			"executable": "ocrd-cis-ocropy-dewarp",
+			"categories": [
+				"Text recognition and optimization"
+			],
+			"steps": [
+				"preprocessing/optimization/dewarping"
+			],
+			"description": "Dewarp line images with ocropy",
+			"input_file_grp": [
+				"OCR-D-SEG-LINE"
+			],
+			"output_file_grp": [
+				"OCR-D-SEG-LINE"
+			],
+			"parameters": {
+				"range": {
+					"type": "number",
+					"description": "maximum vertical disposition or maximum margin (will be multiplied by mean centerline deltas to yield pixels)",
+					"default": 4
+				}
+			}
+		},
 		"ocrd-cis-ocropy-recognize": {
 			"executable": "ocrd-cis-ocropy-recognize",
 			"categories": [
@@ -54,21 +148,20 @@
 			"steps": [
 				"recognition/text-recognition"
 			],
-			"description": "Recognize text in lines with ocropy",
+			"description": "Recognize text in (binarized+deskewed+dewarped) lines with ocropy",
+			"input_file_grp": [
+				"OCR-D-SEG-LINE",
+				"OCR-D-SEG-WORD",
+				"OCR-D-SEG-GLYPH"
+			],
+			"output_file_grp": [
+				"OCR-D-OCR-OCRO"
+			],
 			"parameters": {
-                                "dewarping": {
-                                    "type": "boolean",
-                                    "description": "enable line normalization",
-                                    "default": true
-                                },
-                                "binarization": {
-                                    "type": "string",
-                                    "enum": ["none", "global", "otsu", "gauss-otsu", "ocropy"],
-                                    "default": "none"
-                                },
 				"textequiv_level": {
 					"type": "string",
 					"enum": ["line", "word", "glyph"],
+					"description": "PAGE XML hierarchy level granularity to add the TextEquiv results to",
 					"default": "line"
 				},
 				"model": {

--- a/ocrd_cis/ocrd-tool.json
+++ b/ocrd_cis/ocrd-tool.json
@@ -49,7 +49,7 @@
 		"ocrd-cis-ocropy-binarize": {
 			"executable": "ocrd-cis-ocropy-binarize",
 			"categories": [
-				"Text recognition and optimization"
+				"Image preprocessing"
 			],
 			"steps": [
 				"preprocessing/optimization/binarization",
@@ -95,7 +95,7 @@
 		"ocrd-cis-ocropy-deskew": {
 			"executable": "ocrd-cis-ocropy-deskew",
 			"categories": [
-				"Text recognition and optimization"
+				"Image preprocessing"
 			],
 			"steps": [
 				"preprocessing/optimization/deskewing"
@@ -117,10 +117,73 @@
 				}
 			}
 		},
+		"ocrd-cis-ocropy-clip": {
+			"executable": "ocrd-cis-ocropy-clip",
+			"categories": [
+				"Layout analysis"
+			],
+			"steps": [
+				"layout/segmentation/region",
+				"layout/segmentation/line"
+			],
+			"input_file_grp": [
+				"OCR-D-SEG-BLOCK",
+				"OCR-D-SEG-LINE"
+			],
+			"output_file_grp": [
+				"OCR-D-SEG-BLOCK",
+				"OCR-D-SEG-LINE"
+			],
+			"description": "Clip text regions / lines at intersections with neighbours",
+			"parameters": {
+				"level-of-operation": {
+					"type": "string",
+					"enum": ["region", "line"],
+					"description": "PAGE XML hierarchy level granularity to annotate images for",
+					"default": "region"
+				},
+				"min_fraction": {
+					"type": "number",
+					"format": "float",
+					"description": "share of foreground pixels that must be retained by the largest label",
+					"default": 0.7
+				}
+			}
+		},
+		"ocrd-cis-ocropy-resegment": {
+			"executable": "ocrd-cis-ocropy-resegment",
+			"categories": [
+				"Layout analysis"
+			],
+			"steps": [
+				"layout/segmentation/line"
+			],
+			"input_file_grp": [
+				"OCR-D-SEG-LINE"
+			],
+			"output_file_grp": [
+				"OCR-D-SEG-LINE"
+			],
+			"description": "Resegment lines with ocropy (by shrinking annotated polygons)",
+			"parameters": {
+				"min_fraction": {
+					"type": "number",
+					"format": "float",
+					"description": "share of foreground pixels that must be retained by the largest label",
+					"default": 0.8
+				},
+				"extend_margins": {
+					"type": "number",
+					"format": "integer",
+					"description": "number of pixels to extend the input polygons horizontally and vertically before intersecting",
+					"default": 3
+				}
+			}
+		},
 		"ocrd-cis-ocropy-dewarp": {
 			"executable": "ocrd-cis-ocropy-dewarp",
 			"categories": [
-				"Text recognition and optimization"
+				"Image preprocessing"
 			],
 			"steps": [
 				"preprocessing/optimization/dewarping"

--- a/ocrd_cis/ocropy/binarize.py
+++ b/ocrd_cis/ocropy/binarize.py
@@ -1,0 +1,253 @@
+from __future__ import absolute_import
+
+import sys
+import os.path
+import io
+import cv2
+import numpy as np
+from PIL import Image
+
+#import kraken.binarization
+
+from ocrd_utils import getLogger
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import to_xml, AlternativeImageType
+from ocrd import Processor
+from ocrd_utils import MIMETYPE_PAGE
+
+from .. import get_ocrd_tool
+from . import common
+from .common import (
+    image_from_page,
+    image_from_region,
+    image_from_line,
+    save_image_file,
+    pil2array, array2pil,
+    check_line, check_page,
+    # binarize,
+    borderclean,
+    remove_noise)
+
+#sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+LOG = getLogger('processor.OcropyBinarize')
+FILEGRP_IMG = 'OCR-D-IMG-BIN'
+
+def binarize(pil_image, method='ocropy', maxskew=2, margin=4):
+    LOG.debug('binarizing %dx%d image with method=%s', pil_image.width, pil_image.height, method)
+    if method == 'none':
+        return pil_image, 0
+    elif method == 'ocropy':
+        # parameter defaults from ocropy-nlbin:
+        array = pil2array(pil_image)
+        bin, angle = common.binarize(array, maxskew=maxskew)
+        # remove components not extending this many pixels from the border
+        bin = borderclean(bin, margin=margin + int(0.5*(bin.shape[0] - array.shape[0])))
+        return array2pil(bin), angle
+    # equivalent to ocropy, but without deskewing:
+    # elif method == 'kraken':
+    #     image = kraken.binarization.nlbin(pil_image)
+    #     return image, 0
+    # FIXME: add 'sauvola'
+    else:
+        # Convert RGB to OpenCV
+        img = cv2.cvtColor(np.asarray(pil_image), cv2.COLOR_RGB2GRAY)
+
+        if method == 'global':
+            # global thresholding
+            _, th = cv2.threshold(img,127,255,cv2.THRESH_BINARY)
+        elif method == 'otsu':
+            # Otsu's thresholding
+            _, th = cv2.threshold(img,0,255,cv2.THRESH_BINARY+cv2.THRESH_OTSU)
+        elif method == 'gauss-otsu':
+            # Otsu's thresholding after Gaussian filtering
+            blur = cv2.GaussianBlur(img, (5, 5), 0)
+            _, th = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY+cv2.THRESH_OTSU)
+        else:
+            raise Exception('unknown binarization method %s', method)
+        
+        return Image.fromarray(th), 0
+
+
+class OcropyBinarize(Processor):
+
+    def __init__(self, *args, **kwargs):
+        self.ocrd_tool = get_ocrd_tool()
+        kwargs['ocrd_tool'] = self.ocrd_tool['tools']['ocrd-cis-ocropy-binarize']
+        kwargs['version'] = self.ocrd_tool['version']
+        super(OcropyBinarize, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Binarize and deskew the pages / regions / lines of the workspace.
+        
+        Open and deserialise PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the requested
+        `level-of-operation`.
+        
+        Next, for each file, crop each segment image according to the layout
+        annotation (via coordinates into the higher-level image, or from the
+        alternative image), and determine the threshold for binarization and
+        the deskewing angle of the segment (up to `maxskew`). Apply results
+        to the image and export it as an image file.
+        
+        Add the new image file to the workspace with a fileGrp USE equal
+        `OCR-D-IMG-BIN` and an ID based on input file and input element.
+        
+        Reference each new image in the AlternativeImage of the element.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        method = self.parameter['method']
+        maxskew = self.parameter['maxskew']
+        noise_maxsize = self.parameter['noise_maxsize']
+        level = self.parameter['level-of-operation']
+        
+        for (n, input_file) in enumerate(self.input_files):
+            LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
+            file_id = input_file.ID.replace(self.input_file_grp, FILEGRP_IMG)
+            
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page_id = pcgts.pcGtsId or input_file.pageId # (PageType has no id)
+            page = pcgts.get_Page()
+            page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
+            # process page:
+            page_image, page_xywh = image_from_page(
+                self.workspace, page, page_image, page_id)
+            
+            if level == 'page':
+                self.process_page(page, page_image, page_xywh,
+                                  input_file.pageId, file_id)
+            else:
+                regions = page.get_TextRegion()
+                if not regions:
+                    LOG.warning('Page "%s" contains no text regions', page_id)
+                for region in regions:
+                    region_image, region_xywh = image_from_region(
+                        self.workspace, region, page_image, page_xywh, page_id)
+                    if level == 'region':
+                        self.process_region(region, region_image, region_xywh,
+                                            input_file.pageId, file_id + '_' + region.id)
+                        continue
+                    lines = region.get_TextLine()
+                    if not lines:
+                        LOG.warning('Page "%s" region "%s" contains no text lines', page_id, region.id)
+                    for line in lines:
+                        line_image, line_xywh = image_from_line(
+                            self.workspace, line, region_image, region_xywh, region.id, page_id)
+                        self.process_line(line, line_image, line_xywh,
+                                          input_file.pageId, region.id,
+                                          file_id + '_' + region.id + '_' + line.id)
+            
+            # update METS (add the PAGE file):
+            file_id = input_file.ID.replace(self.input_file_grp,
+                                            self.output_file_grp)
+            file_path = os.path.join(self.output_file_grp,
+                                     file_id + '.xml')
+            out = self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                local_filename=file_path,
+                mimetype=MIMETYPE_PAGE,
+                content=to_xml(pcgts))
+            LOG.info('created file ID: %s, file_grp: %s, path: %s',
+                     file_id, self.output_file_grp, out.local_filename)
+    
+    def process_page(self, page, page_image, page_xywh, page_id, file_id):
+        LOG.info("About to binarize page '%s'", page_id)
+        bin_image, angle = binarize(page_image,
+                                    method=self.parameter['method'],
+                                    maxskew=self.parameter['maxskew'],
+                                    margin=16)
+        bin_image = remove_noise(bin_image,
+                                 maxsize=self.parameter['noise_maxsize'])
+        # annotate angle in PAGE (to allow consumers of the AlternativeImage
+        # to do consistent coordinate transforms, and non-consumers
+        # to redo the rotation themselves):
+        #page.set_orientation(-angle) # does not exist on page level!
+        # update METS (add the image file):
+        file_path = save_image_file(
+            self.workspace,
+            bin_image,
+            file_id,
+            page_id=page_id,
+            file_grp=FILEGRP_IMG)
+        # update PAGE (reference the image file):
+        page.add_AlternativeImage(AlternativeImageType(
+            filename=file_path,
+            comments=('grayscale_normalized' + 
+                      (',cropped' if page_xywh['x'] or page_xywh['y'] else '') +
+                      (',despeckled' if self.parameter['noise_maxsize'] else '') +
+                      (',deskewed' if angle else ''))))
+    
+    def process_region(self, region, region_image, region_xywh, page_id, file_id):
+        LOG.info("About to binarize page '%s' region '%s'", page_id, region.id)
+        # NOTE: This just assumes that an existing TextRegion/@orientation
+        # annotation is already applied in (the last) AlternativeImage if such
+        # images are referenced. One could additionally check whether
+        # its @comments contain the string "deskewed" (as recommended
+        # by the OCR-D spec), but that would in other respects be an
+        # even strong assumption.
+        if region_xywh['angle'] and not region.get_AlternativeImage():
+            # orientation has already been annotated (by previous deskewing),
+            # but not applied yet (into a binary image); so skip deskewing here:
+            bin_image, _ = binarize(region_image,
+                                    method=self.parameter['method'],
+                                    maxskew=0,
+                                    margin=8)
+        else:
+            bin_image, angle = binarize(region_image,
+                                        method=self.parameter['method'],
+                                        maxskew=self.parameter['maxskew'],
+                                        margin=8)
+            # if orientation has already been annotated (by previous deskewing),
+            # then it has also been applied (into a binary image); so here
+            # our deskewing was additive
+            region_xywh['angle'] += angle
+        bin_image = remove_noise(bin_image,
+                                 maxsize=self.parameter['noise_maxsize'])
+        # annotate angle in PAGE (to allow consumers of the AlternativeImage
+        # to do consistent coordinate transforms, and non-consumers
+        # to redo the rotation themselves):
+        region.set_orientation(-region_xywh['angle'])
+        # update METS (add the image file):
+        file_path = save_image_file(
+            self.workspace,
+            bin_image,
+            file_id=file_id,
+            page_id=page_id,
+            file_grp=FILEGRP_IMG)
+        # update PAGE (reference the image file):
+        region.add_AlternativeImage(AlternativeImageType(
+            filename=file_path,
+            comments=('grayscale_normalized,cropped' + 
+                      (',despeckled' if self.parameter['noise_maxsize'] else '') +
+                      (',deskewed' if region_xywh['angle'] else ''))))
+    
+    def process_line(self, line, line_image, line_xywh, page_id, region_id, file_id):
+        LOG.info("About to binarize page '%s' region '%s' line '%s'",
+                 page_id, region_id, line.id)
+        bin_image, angle = binarize(line_image,
+                                    method=self.parameter['method'],
+                                    maxskew=self.parameter['maxskew'],
+                                    margin=4)
+        # annotate angle in PAGE (to allow consumers of the AlternativeImage
+        # to do consistent coordinate transforms, and non-consumers
+        # to redo the rotation themselves):
+        #line.set_orientation(-angle) # does not exist on line level!
+        bin_image = remove_noise(bin_image,
+                                 maxsize=self.parameter['noise_maxsize'])
+        # update METS (add the image file):
+        file_path = save_image_file(
+            self.workspace,
+            bin_image,
+            file_id=file_id,
+            page_id=page_id,
+            file_grp=FILEGRP_IMG)
+        # update PAGE (reference the image file):
+        line.add_AlternativeImage(AlternativeImageType(
+            filename=file_path,
+            comments=('grayscale_normalized,cropped' + 
+                      (',despeckled' if self.parameter['noise_maxsize'] else '') +
+                      (',deskewed' if angle else ''))))
+        

--- a/ocrd_cis/ocropy/cli.py
+++ b/ocrd_cis/ocropy/cli.py
@@ -3,6 +3,8 @@ import click, os
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
 from ocrd_cis.ocropy.binarize import OcropyBinarize
 from ocrd_cis.ocropy.deskew import OcropyDeskew
+from ocrd_cis.ocropy.clip import OcropyClip
+from ocrd_cis.ocropy.resegment import OcropyResegment
 from ocrd_cis.ocropy.dewarp import OcropyDewarp
 from ocrd_cis.ocropy.recognize import OcropyRecognize
 from ocrd_cis.ocropy.train import OcropyTrain
@@ -18,6 +20,16 @@ def cis_ocrd_ocropy_binarize(*args, **kwargs):
 @ocrd_cli_options
 def cis_ocrd_ocropy_deskew(*args, **kwargs):
     return ocrd_cli_wrap_processor(OcropyDeskew, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def cis_ocrd_ocropy_clip(*args, **kwargs):
+    return ocrd_cli_wrap_processor(OcropyClip, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def cis_ocrd_ocropy_resegment(*args, **kwargs):
+    return ocrd_cli_wrap_processor(OcropyResegment, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_cis/ocropy/cli.py
+++ b/ocrd_cis/ocropy/cli.py
@@ -1,11 +1,28 @@
 import click, os
 
 from ocrd.decorators import ocrd_cli_options, ocrd_cli_wrap_processor
+from ocrd_cis.ocropy.binarize import OcropyBinarize
+from ocrd_cis.ocropy.deskew import OcropyDeskew
+from ocrd_cis.ocropy.dewarp import OcropyDewarp
 from ocrd_cis.ocropy.recognize import OcropyRecognize
 from ocrd_cis.ocropy.train import OcropyTrain
 from ocrd_cis.ocropy.rec import OcropyRec
 
 
+@click.command()
+@ocrd_cli_options
+def cis_ocrd_ocropy_binarize(*args, **kwargs):
+    return ocrd_cli_wrap_processor(OcropyBinarize, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def cis_ocrd_ocropy_deskew(*args, **kwargs):
+    return ocrd_cli_wrap_processor(OcropyDeskew, *args, **kwargs)
+
+@click.command()
+@ocrd_cli_options
+def cis_ocrd_ocropy_dewarp(*args, **kwargs):
+    return ocrd_cli_wrap_processor(OcropyDewarp, *args, **kwargs)
 
 @click.command()
 @ocrd_cli_options

--- a/ocrd_cis/ocropy/clip.py
+++ b/ocrd_cis/ocropy/clip.py
@@ -1,0 +1,229 @@
+from __future__ import absolute_import
+
+import sys
+import os.path
+import io
+import numpy as np
+from skimage import measure, draw
+import cv2
+from scipy.ndimage import filters
+
+from ocrd_utils import getLogger
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import (
+    to_xml, AlternativeImageType,
+    TextRegionType, TextLineType
+)
+from ocrd_models import OcrdExif
+from ocrd import Processor
+from ocrd_utils import MIMETYPE_PAGE
+
+from .. import get_ocrd_tool
+from . import common
+from .ocrolib import midrange, morph
+from .common import (
+    coordinates_of_segment,
+    xywh_from_points,
+    bbox_from_polygon,
+    image_from_page,
+    image_from_region,
+    image_from_polygon,
+    polygon_mask,
+    crop_image,
+    pil2array, array2pil,
+    # binarize,
+    save_image_file
+)
+
+#sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+TOOL = 'ocrd-cis-ocropy-clip'
+LOG = getLogger('processor.OcropyClip')
+FILEGRP_IMG = 'OCR-D-IMG-CLIP'
+
+class OcropyClip(Processor):
+
+    def __init__(self, *args, **kwargs):
+        self.ocrd_tool = get_ocrd_tool()
+        kwargs['ocrd_tool'] = self.ocrd_tool['tools'][TOOL]
+        kwargs['version'] = self.ocrd_tool['version']
+        super(OcropyClip, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Clip text regions / lines of the workspace at intersections with neighbours.
+        
+        Open and deserialise PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the requested
+        `level-of-operation`.
+        
+        Next, get each segment image according to the layout annotation (by cropping
+        via coordinates into the higher-level image), as well as all its neighbours',
+        binarize them (without deskewing), and make a connected component analysis.
+        (Segments must not already have AlternativeImage or orientation angle
+         annotated, otherwise they will be skipped.)
+        
+        Then, for each section of overlap with a neighbour, re-assign components
+        which are only contained in the neighbour by clipping them to white (background),
+        and export the (final) result as image file.
+        
+        Add the new image file to the workspace with a fileGrp USE equal
+        `OCR-D-IMG-CLIP` and an ID based on the input file and input element.
+        
+        Reference each new image in the AlternativeImage of the element.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        # This makes best sense for overlapping segmentation, like current GT
+        # or Tesseract layout analysis. Most notably, it can suppress graphics
+        # and separators within or across a region or line. It _should_ ideally
+        # be run after binarization (on page level for region-level clipping,
+        # and on the region level for line-level clipping), because the
+        # connected component analysis after implicit binarization could be
+        # suboptimal, and the explicit binarization after clipping could be,
+        # too. However, region-level clipping _must_ be run before region-level
+        # deskewing, because that would make segments incomensurable with their
+        # neighbours.
+        level = self.parameter['level-of-operation']
+        
+        for (n, input_file) in enumerate(self.input_files):
+            LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
+            file_id = input_file.ID.replace(self.input_file_grp, FILEGRP_IMG)
+            if file_id == input_file.ID:
+                file_id = concat_padded(FILEGRP_IMG, n)
+            
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
+            page = pcgts.get_Page()
+            page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
+            page_image_info = OcrdExif(page_image)
+            if page_image_info.xResolution != 1:
+                dpi = page_image_info.xResolution
+                if page_image_info.resolutionUnit == 'cm':
+                    dpi = round(dpi * 2.54)
+                LOG.info('Page "%s" uses %d DPI', page_id, dpi)
+                zoom = 300.0/dpi
+            else:
+                zoom = 1
+            page_image, page_xywh = image_from_page(
+                self.workspace, page, page_image, page_id)
+            
+            regions = page.get_TextRegion()
+            other_regions = (
+                page.get_AdvertRegion() + 
+                page.get_ChartRegion() +
+                page.get_ChemRegion() +
+                page.get_GraphicRegion() +
+                page.get_ImageRegion() +
+                page.get_LineDrawingRegion() +
+                page.get_MathsRegion() +
+                page.get_MusicRegion() +
+                page.get_NoiseRegion() +
+                page.get_SeparatorRegion() +
+                page.get_TableRegion() +
+                page.get_UnknownRegion())
+            if not regions:
+                LOG.warning('Page "%s" contains no text regions', page_id)
+            for i, region in enumerate(regions):
+                if level == 'region':
+                    if region.get_AlternativeImage():
+                        LOG.warning('Page "%s" region "%s" already contains image data: skipping',
+                                    page_id, region.id)
+                        continue
+                    if region.get_orientation():
+                        LOG.warning('Page "%s" region "%s" has non-zero orientation: skipping',
+                                    page_id, region.id)
+                        continue
+                    self.process_segment(region, regions[:i] + regions[i+1:] + other_regions,
+                                         page_image, page_xywh,
+                                         input_file.pageId, file_id + '_' + region.id)
+                    continue
+                region_image, region_xywh = image_from_region(
+                    self.workspace, region, page_image, page_xywh)
+                lines = region.get_TextLine()
+                if not lines:
+                    LOG.warning('Page "%s" region "%s" contains no text lines', page_id, region.id)
+                    continue
+                for j, line in enumerate(lines):
+                    if line.get_AlternativeImage():
+                        LOG.warning('Page "%s" region "%s" line "%s" already contains image data: skipping',
+                                    page_id, region.id, line.id)
+                        continue
+                    self.process_segment(line, lines[:j] + lines[j+1:],
+                                         region_image, region_xywh,
+                                         input_file.pageId, file_id + '_' + region.id + '_' + line.id)
+            
+            # update METS (add the PAGE file):
+            file_id = input_file.ID.replace(self.input_file_grp,
+                                            self.output_file_grp)
+            if file_id == input_file.ID:
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp,
+                                     file_id + '.xml')
+            out = self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                local_filename=file_path,
+                mimetype=MIMETYPE_PAGE,
+                content=to_xml(pcgts))
+            LOG.info('created file ID: %s, file_grp: %s, path: %s',
+                     file_id, self.output_file_grp, out.local_filename)
+    
+    def process_segment(self, segment, neighbours, parent_image, parent_xywh, page_id, file_id):
+        segment_xywh = xywh_from_points(segment.get_Coords().points)
+        segment_polygon = coordinates_of_segment(segment, parent_image, parent_xywh)
+        segment_bbox = bbox_from_polygon(segment_polygon)
+        segment_image = image_from_polygon(parent_image, segment_polygon)
+        segment_mask = pil2array(polygon_mask(parent_image, segment_polygon)).astype(np.uint8)
+        # ad-hoc binarization:
+        parent_array = pil2array(parent_image)
+        parent_array, _ = common.binarize(parent_array, maxskew=0) # just in case still raw
+        parent_bin = np.array(parent_array <= midrange(parent_array), np.uint8)
+        for neighbour in neighbours:
+            neighbour_polygon = coordinates_of_segment(neighbour, parent_image, parent_xywh)
+            neighbour_bbox = bbox_from_polygon(neighbour_polygon)
+            # not as precise as a (mutual) polygon intersection test, but that would add
+            # a dependency on `shapely` (and we only loose a little speed here):
+            if not (segment_bbox[2] >= neighbour_bbox[0] and
+                    neighbour_bbox[2] >= segment_bbox[0] and
+                    segment_bbox[3] >= neighbour_bbox[1] and
+                    neighbour_bbox[3] >= segment_bbox[1]):
+                continue
+            neighbour_mask = pil2array(polygon_mask(parent_image, neighbour_polygon)).astype(np.uint8)
+            # extend mask by 3 pixel in each direction to ensure it does not leak components accidentally
+            # (accounts for bad cropping of non-text regions in GT):
+            if not isinstance(neighbour, (TextRegionType, TextLineType)):
+                neighbour_mask = filters.maximum_filter(neighbour_mask, 7)
+            # find connected components that (only) belong to the neighbour:
+            intruders = segment_mask * morph.keep_marked(parent_bin, neighbour_mask > 0) # overlaps neighbour
+            intruders -= morph.keep_marked(intruders, segment_mask - neighbour_mask > 0) # but exclusively
+            num_intruders = np.count_nonzero(intruders)
+            num_foreground = np.count_nonzero(segment_mask * parent_bin)
+            if not num_intruders:
+                continue
+            if num_intruders / num_foreground > 1.0 - self.parameter['min_fraction']:
+                LOG.info('Too many intruders (%d/%d) from neighbour "%s" in segment "%s" on page "%s"',
+                         num_intruders, num_foreground, neighbour.id, segment.id, page_id)
+                continue
+            LOG.debug('segment "%s" vs neighbour "%s": suppressing %d pixels on page "%s"',
+                      segment.id, neighbour.id, np.count_nonzero(intruders), page_id)
+            clip_mask = array2pil(intruders)
+            #parent_bin[intruders] = 0 # suppress in binary for next iteration
+            segment_image.paste(clip_mask, mask=clip_mask) # suppress in raw image
+        # recrop segment into rectangle (also clipping with white):
+        segment_image = crop_image(segment_image,
+            box=(segment_xywh['x'] - parent_xywh['x'],
+                 segment_xywh['y'] - parent_xywh['y'],
+                 segment_xywh['x'] - parent_xywh['x'] + segment_xywh['w'],
+                 segment_xywh['y'] - parent_xywh['y'] + segment_xywh['h']))
+        # update METS (add the image file):
+        file_path = save_image_file(
+            self.workspace,
+            segment_image,
+            file_id=file_id,
+            page_id=page_id,
+            file_grp=FILEGRP_IMG)
+        # update PAGE (reference the image file):
+        segment.add_AlternativeImage(AlternativeImageType(
+            filename=file_path,
+            comments='cropped,clipped'))

--- a/ocrd_cis/ocropy/common.py
+++ b/ocrd_cis/ocropy/common.py
@@ -1,0 +1,800 @@
+from __future__ import absolute_import
+
+import os.path
+import io
+import warnings
+
+import numpy as np
+from scipy.ndimage import measurements, filters, interpolation, morphology
+from scipy import stats
+from PIL import Image, ImageDraw
+
+from ocrd_cis.ocropy import ocrolib
+from ocrd_cis.ocropy.ocrolib import lineest, morph, psegutils, sl
+
+from ocrd_utils import getLogger, xywh_from_points, polygon_from_points
+
+LOG = getLogger('') # to be refined by importer
+
+# method similar to ocrolib.read_image_gray
+def pil2array(image):
+    """Convert image to floating point grayscale array.
+    
+    Given a PIL.Image instance (of any colorspace),
+    convert to a grayscale Numpy array
+    (with 1.0 for white and 0.0 for black).
+    """
+    assert isinstance(image, Image.Image), "not a PIL.Image"
+    array = ocrolib.pil2array(image)
+    if array.dtype == np.uint8:
+        array = array / 255.0
+    if array.dtype == np.int8:
+        array = array / 127.0
+    elif array.dtype == np.uint16:
+        array = array / 65536.0
+    elif array.dtype == np.int16:
+        array = array / 32767.0
+    elif np.issubdtype(array.dtype, np.floating):
+        pass
+    else:
+        raise Exception("unknown image type: " + array.dtype)
+    if array.ndim == 3:
+        array = np.mean(array, 2)
+    return array
+
+def array2pil(array):
+    """Convert floating point grayscale array to an image.
+    
+    Given a grayscale Numpy array
+    (with 1.0 for white and 0.0 for black),
+    convert to a (grayscale) PIL.Image instance.
+    """
+    assert isinstance(array, np.ndarray), "not a numpy array"
+    array = np.array(255.0 * array, np.uint8)
+    return ocrolib.array2pil(array)
+
+# from ocropy-nlbin, but keeping exact size
+def estimate_local_whitelevel(image, zoom=0.5, perc=80, range_=20):
+    '''flatten it by estimating the local whitelevel
+    zoom for page background estimation, smaller=faster, default: %(default)s
+    percentage for filters, default: %(default)s
+    range for filters, default: %(default)s
+    '''
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        m = interpolation.zoom(image, zoom, mode='nearest')
+        m = filters.percentile_filter(m, perc, size=(range_, 2))
+        m = filters.percentile_filter(m, perc, size=(2, range_))
+        m = interpolation.zoom(m, 1. / zoom)
+    #w, h = np.minimum(np.array(image.shape), np.array(m.shape))
+    #flat = np.clip(image[:w, :h] - m[:w, :h] + 1, 0, 1)
+    # we want to get exactly the same size as before:
+    h, w = image.shape
+    h0, w0 = m.shape
+    m = np.pad(m, ((max(0, h-h0),0), (max(0, w-w0),0)), 'edge')[:h, :w]
+    flat = np.nan_to_num(np.clip(image - m + 1, 0, 1))
+    return flat
+
+# from ocropy-nlbin
+def estimate_skew_angle(image, angles):
+    estimates = []
+    for a in angles:
+        v = np.mean(interpolation.rotate(image, a, order=0, mode='constant'), axis=1)
+        v = np.var(v)
+        estimates.append((v, a))
+    _, a = max(estimates)
+    return a
+
+# from ocropy-nlbin, but with reshape=True
+def estimate_skew(flat, bignore=0.1, maxskew=2, skewsteps=8):
+    '''estimate skew angle and rotate'''
+    d0, d1 = flat.shape
+    o0, o1 = int(bignore * d0), int(bignore * d1) # border ignore
+    flat = np.amax(flat) - flat
+    #flat -= np.amin(flat)
+    est = flat[o0:d0 - o0, o1:d1 - o1]
+    ma = maxskew
+    ms = int(2 * maxskew * skewsteps)
+    angles = np.linspace(-ma, ma, ms + 1)
+    # if d0 > d1 and d0 * d1 > 300:
+    #     angles = np.concatenate([angles,
+    #                              angles + 90])
+    angle = estimate_skew_angle(est, angles)
+    # we must allow reshape/expand to avoid loosing information in the corners
+    # (but this also means that consumers of the AlternativeImage must
+    #  offset coordinates by half the increased width/height besides
+    #  correcting for rotation in the coordinates):
+    flat = interpolation.rotate(flat, angle, mode='constant', reshape=True)
+    flat = np.amax(flat) - flat
+    return flat, angle
+
+# from ocropy-nlbin
+def estimate_thresholds(flat, bignore=0.1, escale=1.0, lo=5, hi=90):
+    '''estimate low and high thresholds.
+    ignore this much of the border for threshold estimation, default: %(default)s
+    scale for estimating a mask over the text region, default: %(default)s
+    lo percentile for black estimation, default: %(default)s
+    hi percentile for white estimation, default: %(default)s
+    '''
+    d0, d1 = flat.shape
+    o0, o1 = int(bignore * d0), int(bignore * d1)
+    est = flat[o0:d0 - o0, o1:d1 - o1]
+    if escale > 0:
+        # by default, we use only regions that contain
+        # significant variance; this makes the percentile
+        # based low and high estimates more reliable
+        e = escale
+        v = est - filters.gaussian_filter(est, e * 20.0)
+        v = filters.gaussian_filter(v ** 2, e * 20.0) ** 0.5
+        v = (v > 0.3 * np.amax(v))
+        v = morphology.binary_dilation(v, structure=np.ones((int(e * 50), 1)))
+        v = morphology.binary_dilation(v, structure=np.ones((1, int(e * 50))))
+        est = est[v]
+    lo = stats.scoreatpercentile(est.ravel(), lo)
+    hi = stats.scoreatpercentile(est.ravel(), hi)
+    return lo, hi
+
+# from ocropy-nlbin process1, but reshape when rotating
+def binarize(image, 
+             perc=90, # percentage for local whitelevel filters (ocropy: 80)
+             range=10, # range (in pixels) for local whitelevel filters (ocropy: 20)
+             zoom=1.0, # zoom factor for local whitelevel filters (ocropy: 0.5)
+             escale=1.0, # exp scale for region mask during threshold estimation
+             bignore=0.1, # ignore this much of the border for threshold estimation
+             threshold=0.5, # final binarization threshold (ocropy: 0.5)
+             lo=5, # percentile for black estimation (ocropy: 5)
+             hi=90, # percentile for white estimation (ocropy: 90)
+             maxskew=2, # maximum angle (in degrees) for skew estimation
+             skewsteps=8): # steps per degree
+    extreme = (np.sum(image < 0.05) + np.sum(image > 0.95)) * 1.0 / np.prod(image.shape)
+    if extreme > 0.95:
+        comment = "no-normalization"
+        flat = image
+    else:
+        comment = ""
+        # if not, we need to flatten it by estimating the local whitelevel
+        flat = estimate_local_whitelevel(image, zoom, perc, range)
+    if maxskew > 0:
+        flat, angle = estimate_skew(flat, bignore, maxskew, skewsteps)
+    else:
+        angle = 0
+    lo, hi = estimate_thresholds(flat, bignore, escale, lo, hi)
+    # rescale the image to get the gray scale image
+    flat -= lo
+    flat /= (hi - lo)
+    flat = np.clip(flat, 0, 1)
+    bin = 1 * (flat > threshold)
+    LOG.debug("binarization: lo-hi (%.2f %.2f) angle %4.1f %s", lo, hi, angle, comment)
+    return bin, angle
+
+# inspired by OLD/ocropus-lattices --borderclean
+def borderclean(array, margin=4):
+    """Remove components that are only contained within the margin.
+    
+    Given a grayscale-normalized image as Numpy array `array`, 
+    find and remove those black components that do not exceed
+    the top/bottom margins.
+    (This can be used to get rid of ascenders and descenders from
+    neighbouring regions/lines, which cannot be found by resegment().
+    But this should happen before deskewing, because this increases
+    the margins by an unpredictable amount.)
+    
+    Return a Numpy array.
+    """
+    binary = np.array(array <= ocrolib.midrange(array), np.uint8)
+    h, w = array.shape
+    h1, w1 = min(margin, h//2 - 4), min(margin, w//2 - 4)
+    h2, w2 = -h1 if h1 else h, -w1 if w1 else w
+    mask = np.zeros(array.shape, 'i')
+    #mask[h1:h2, w1:w2] = 1
+    # use only the vertical margins (to which recognition is sensitive):
+    mask[h1:h2, :] = 1
+    _, ncomps_before = morph.label(binary)
+    binary = morph.keep_marked(binary, mask)
+    _, ncomps_after = morph.label(binary)
+    LOG.debug('black components before/after borderclean (margin=%d): %d/%d',
+              margin, ncomps_before, ncomps_after)
+    return np.maximum((1 - binary)*(1 - mask), array)
+
+# from ocropus-rpred
+def check_line(array):
+    """Validate array as a plausible text line image.
+    
+    Given a binarized, inverted image as Numpy array `array`
+    (with 0 for white and 1 for black),
+    check the array has the right dimensions, is in fact inverted,
+    and does not have too few or too many connected black components.
+    
+    Returns an error report, or None if valid.
+    """
+    if len(array.shape)==3: return "input image is color image %s"%(array.shape,)
+    if np.mean(array)<np.median(array): return "image may be inverted"
+    h,w = array.shape
+    if h<20: return "image not tall enough for a text line %s"%(array.shape,)
+    if h>200: return "image too tall for a text line %s"%(array.shape,)
+    #if w<1.5*h: return "line too short %s"%(array.shape,)
+    if w<1.5*h and w<32: return "line too short %s"%(array.shape,)
+    if w>4000: return "line too long %s"%(array.shape,)
+    ratio = w*1.0/h
+    _,ncomps = measurements.label(array>np.mean(array))
+    lo = int(0.5*ratio+0.5)
+    hi = int(4*ratio)+1
+    if ncomps<lo: return "too few connected components (got %d, wanted >=%d)"%(ncomps,lo)
+    #if ncomps>hi*ratio: return "too many connected components (got %d, wanted <=%d)"%(ncomps,hi)
+    if ncomps>hi*ratio and ncomps>10: return "too many connected components (got %d, wanted <=%d)"%(ncomps,hi)
+    return None
+
+# inspired by ocropus-gpageseg check_page
+def check_region(array):
+    """Validate array as a plausible text region image.
+    
+    Given a binarized, inverted image as Numpy array `array`
+    (with 0 for white and 1 for black),
+    check the array has the right dimensions, is in fact inverted,
+    and does not have too few or too many connected black components.
+    
+    Returns an error report, or None if valid.
+    """
+    if len(array.shape)==3: return "input image is color image %s"%(array.shape,)
+    if np.mean(array)<np.median(array): return "image may be inverted"
+    h,w = array.shape
+    if h<100: return "image not tall enough for a region image %s"%(array.shape,)
+    if h>5000: return "image too tall for a region image %s"%(array.shape,)
+    if w<100: return "image too narrow for a region image %s"%(array.shape,)
+    if w>5000: return "line too wide for a region image %s"%(array.shape,)
+    slots = int(w*h*1.0/(30*30))
+    _,ncomps = measurements.label(array>np.mean(array))
+    if ncomps<5: return "too few connected components for a region image (got %d)"%(ncomps,)
+    if ncomps>slots*2 and ncomps>10: return "too many connnected components for a region image (%d > %d)"%(ncomps,slots)
+    return None
+
+# from ocropus-gpageseg
+def check_page(array):
+    """Validate array as a plausible printed text page image.
+    
+    Given a binarized, inverted image as Numpy array `array`
+    (with 0 for white and 1 for black),
+    check the array has the right dimensions, is in fact inverted,
+    and does not have too few or too many connected black components.
+    
+    Returns an error report, or None if valid.
+    """
+    if len(array.shape)==3: return "input image is color image %s"%(array.shape,)
+    if np.mean(array)<np.median(array): return "image may be inverted"
+    h,w = array.shape
+    if h<600: return "image not tall enough for a page image %s"%(array.shape,)
+    if h>10000: return "image too tall for a page image %s"%(array.shape,)
+    if w<600: return "image too narrow for a page image %s"%(array.shape,)
+    if w>10000: return "line too wide for a page image %s"%(array.shape,)
+    slots = int(w*h*1.0/(30*30))
+    _,ncomps = measurements.label(array>np.mean(array))
+    if ncomps<10: return "too few connected components for a page image (got %d)"%(ncomps,)
+    if ncomps>slots and ncomps>10: return "too many connnected components for a page image (%d > %d)"%(ncomps,slots)
+    return None
+
+def odd(num):
+    return num + (num+1)%2
+
+# from ocropus-gpageseg
+def DSAVE(title,array):
+    from matplotlib import pyplot as plt
+    from matplotlib import patches as mpatches
+    if type(array)==list:
+        assert len(array)==3
+        array = np.transpose(np.array(array),[1,2,0])
+    #plt.imshow(array.astype('float'))
+    #plt.legend(handles=[mpatches.Patch(label=title)])
+    #plt.show()
+    fname = title+".png"
+    plt.imsave(fname,array.astype('float'))
+
+# from ocropus-gpageseg    
+def compute_separators_morph(binary,scale, sepwiden=10, maxseps=0):
+    """Finds vertical black lines corresponding to column separators."""
+    d0 = int(max(5,scale/4))
+    d1 = int(max(5,scale))+ sepwiden
+    thick = morph.r_dilation(binary,(d0,d1))
+    vert = morph.rb_opening(thick,(10*scale,1))
+    vert = morph.r_erosion(vert,(d0//2, sepwiden))
+    vert = morph.select_regions(vert,sl.dim1,min=3,nbest=2* maxseps)
+    vert = morph.select_regions(vert,sl.dim0,min=20*scale,nbest=maxseps)
+    return vert
+
+# from ocropus-gpagseg
+def compute_colseps_conv(binary,scale=1.0, csminheight=10, maxcolseps=2):
+    """Find column separators by convolution and
+    thresholding."""
+    h,w = binary.shape
+    # find vertical whitespace by thresholding
+    smoothed = filters.gaussian_filter(1.0*binary,(scale,scale*0.5))
+    smoothed = filters.uniform_filter(smoothed,(5.0*scale,1))
+    thresh = (smoothed<np.amax(smoothed)*0.1)
+    #DSAVE("1thresh",thresh)
+    # find column edges by filtering
+    grad = filters.gaussian_filter(1.0*binary,(scale,scale*0.5),order=(0,1))
+    grad = filters.uniform_filter(grad,(10.0*scale,1))
+    # grad = abs(grad) # use this for finding both edges
+    grad = (grad>0.5*np.amax(grad))
+    #DSAVE("2grad",grad)
+    # combine edges and whitespace
+    seps = np.minimum(thresh,filters.maximum_filter(grad,(int(scale),int(5*scale))))
+    seps = filters.maximum_filter(seps,(int(2*scale),1))
+    #DSAVE("3seps",seps)
+    # select only the biggest column separators
+    seps = morph.select_regions(seps,sl.dim0,min=csminheight*scale,nbest=maxcolseps)
+    #DSAVE("4seps",seps)
+    return seps
+
+# from ocropus-gpageseg, but without apply_mask (i.e. input file)
+def compute_colseps(binary,scale, maxcolseps=3, maxseps=0):
+    """Computes column separators either from vertical black lines or whitespace."""
+    LOG.debug("considering at most %g whitespace column separators", maxcolseps)
+    colseps = compute_colseps_conv(binary,scale, maxcolseps=maxcolseps)
+    #DSAVE("colwsseps",0.7*colseps+0.3*binary)
+    if maxseps > 0:
+        LOG.debug("considering at most %g black column separators", maxseps)
+        seps = compute_separators_morph(binary,scale, maxseps=maxseps)
+        #DSAVE("colseps",0.7*seps+0.3*binary)
+        #colseps = compute_colseps_morph(binary,scale)
+        colseps = np.maximum(colseps,seps)
+        binary = np.minimum(binary,1-seps)
+    #binary,colseps = apply_mask(binary,colseps)
+    return colseps,binary
+
+# from ocropus-gpageseg, but with additional option vsticky
+def compute_gradmaps(binary,scale,
+                     vsticky=False,
+                     usegauss=False,vscale=1.0,hscale=1.0):
+    # use gradient filtering to find baselines
+    # do not use the default boxmap scale thresholds (0.5,4),
+    # because we will have remainders of (possibly rotated and)
+    # chopped lines at the region boundaries,
+    # which we want to regard as neighbouring full lines
+    # when estimating segmentation to re-segment (and mask) lines:    
+    boxmap = psegutils.compute_boxmap(binary,scale, threshold=(0.1,4))
+    #DSAVE("boxmap",boxmap)
+    cleaned = boxmap*binary
+    #DSAVE("cleaned",cleaned)
+    if usegauss:
+        # this uses Gaussians
+        grad = filters.gaussian_filter(
+            1.0*cleaned,
+            (vscale*0.3*scale,
+             hscale*6*scale),
+            order=(1,0))
+    else:
+        # this uses non-Gaussian oriented filters
+        grad = filters.gaussian_filter(
+            1.0*cleaned,
+            (max(4,vscale*0.3*scale),
+             hscale*scale),
+            order=(1,0))
+        grad = filters.uniform_filter(
+            grad,
+            (vscale,hscale*6*scale))
+        if vsticky:
+            # make gradient stick at top and bottom
+            # so chopped off lines will be used as well
+            grad[0, :] = 0.01
+            grad[-1, :] = -0.01
+    #DSAVE("grad", grad)
+    bottom = ocrolib.norm_max((grad<0)*(-grad))
+    top = ocrolib.norm_max((grad>0)*grad)
+    #DSAVE("bottom+top+boxmap", [boxmap, bottom + 2*top, binary])
+    return bottom,top,boxmap
+
+# from ocropus-gpageseg
+def compute_line_seeds(binary,bottom,top,colseps,scale,
+                       threshold=0.2,vscale=1.0):
+    """Base on gradient maps, computes candidates for baselines
+    and xheights.  Then, it marks the regions between the two
+    as a line seed."""
+    t = threshold
+    vrange = int(vscale*scale)
+    bmarked = filters.maximum_filter(
+        bottom==filters.maximum_filter(bottom,(vrange,0)),
+        (2,2)) * (bottom>t*np.amax(bottom)*t) *(1-colseps)
+    tmarked = filters.maximum_filter(
+        top==filters.maximum_filter(top,(vrange,0)),
+        (2,2)) * (top>t*np.amax(top)*t/2) *(1-colseps)
+    tmarked = filters.maximum_filter(tmarked,(1,10))
+    seeds = np.zeros(binary.shape,'i')
+    delta = max(3,int(scale/2))
+    for x in range(bmarked.shape[1]):
+        transitions = sorted([(y,1) for y in psegutils.find(bmarked[:,x])] +
+                             [(y,0) for y in psegutils.find(tmarked[:,x])])[::-1]
+        transitions += [(0,0)]
+        for l in range(len(transitions)-1):
+            y0,s0 = transitions[l]
+            if s0==0: continue
+            seeds[y0-delta:y0,x] = 1
+            y1,s1 = transitions[l+1]
+            if s1==0 and (y0-y1)<5*scale: seeds[y1:y0,x] = 1
+    seeds = filters.maximum_filter(seeds,(1,int(1+scale)))
+    seeds = seeds*(1-colseps)
+    #DSAVE("lineseeds unlabelled",[seeds,0.3*tmarked+0.7*bmarked,binary])
+    seeds, _ = morph.label(seeds)
+    return seeds
+
+def hmerge_line_seeds(seeds, colseps):
+    # use full horizontal spread to avoid splitting lines at long whitespace
+    # (but only indirectly as masks with a label conflict, so we can
+    #  horizontally merge components, and at the same time avoid to
+    #  horizontally enlarge components in general, which would
+    #  allow corners to become the largest component later-on;
+    #  moreover, ignore conflicts which affect only small fractions
+    #  of either line, so a merge can be avoided for small vertical overlap):
+    relabel = np.unique(seeds)
+    labels = np.delete(relabel, 0) # without background
+    labels_count = dict([(label, np.sum(seeds == label)) for label in labels])
+    overlap_count = dict([(label, (0, label)) for label in labels])
+    for label in labels:
+        # get maximum horizontal spread for current label:
+        mask = filters.maximum_filter(seeds == label, (1, seeds.shape[1]))
+        # get overlap between other labels and mask (but discount colseps):
+        candidates, counts = np.unique(seeds * mask * (1-colseps), return_counts=True)
+        for candidate, count in zip(candidates, counts):
+            if (candidate and candidate != label and
+                overlap_count[candidate][0] < count):
+                overlap_count[candidate] = (count, label)
+    for label in labels:
+        count, candidate = overlap_count[label]
+        if count / labels_count[label] > 0.2:
+            relabel[label] = relabel[candidate]
+    seeds = relabel[seeds]
+    #DSAVE("lineseeds hmerged", seeds)
+    return seeds
+
+# like ocropus-gpageseg compute_segmentation, but with fullpage switch, with larger scale, smaller hscale and horizontal merge, and without final unmasking
+def compute_line_labels(array, fullpage=False, maxcolseps=2, maxseps=0):
+    """Find text line segmentation within a region or page.
+    
+    Given a binarized image as Numpy array `array`, compute a complete segmentation
+    into text lines, avoiding horizontal splits. If `fullpage` is True, then also
+    find up to `maxcolseps` white-space and up to `maxseps` black column separators.
+    
+    Return the background label array (not the foreground or the masked image).
+    """
+    if np.prod(array.shape) == 0:
+        raise Exception('image dimensions are zero')
+    if np.amax(array) == np.amin(array):
+        raise Exception('image is blank')
+    binary = np.array(array <= ocrolib.midrange(array), np.uint8)
+    #DSAVE("binary",binary)
+    if fullpage:
+        report = check_page(binary)
+    else:
+        report = check_region(binary)
+    if report:
+        raise Exception(report)
+    scale = psegutils.estimate_scale(binary)
+    # use larger scale so broken/blackletter fonts with their large capitals
+    # are not cut into two lines:
+    scale *= 2
+    LOG.debug('xheight: %d, scale: %d', binary.shape[0], scale)
+    bottom, top, boxmap = compute_gradmaps(binary, scale, usegauss=False,
+                                           # make top and bottom sticky so chopped-off
+                                           # lines are not merged with neighbours:
+                                           vsticky=not fullpage,
+                                           # use small scale so broken/blackletter fonts
+                                           # (with their large capitals)
+                                           # can be approximated with enough precision:
+                                           hscale=0.2, vscale=0.5)
+    if fullpage:
+        colseps, _ = compute_colseps(binary, scale, maxcolseps=maxcolseps, maxseps=maxseps)
+    else:
+        colseps = np.zeros(binary.shape, np.uint8)
+    seeds = compute_line_seeds(binary, bottom, top, colseps, scale)
+    #DSAVE("seeds",[bottom,top,boxmap])
+    seeds = hmerge_line_seeds(seeds, colseps)
+
+    # spread the text line seeds to all the remaining
+    # components
+    # (boxes with overlapping seeds will become background:)
+    llabels = morph.propagate_labels(boxmap,seeds,conflict=0)
+    spread = morph.spread_labels(seeds,maxdist=scale)
+    #DSAVE('spread', spread)
+    # (background and conflict will get nearest seed:)
+    llabels = np.where(llabels>0,llabels,spread)
+    #DSAVE('llabels', llabels)
+    #segmentation = llabels*binary
+    #return segmentation
+    return llabels
+
+# from ocropus-gpageseg, but as separate step on the PIL.Image
+def remove_noise(image, maxsize=8):
+    array = pil2array(image)
+    binary = np.array(array <= ocrolib.midrange(array), np.uint8)
+    _, ncomps_before = morph.label(binary)
+    binary = ocrolib.remove_noise(binary, maxsize)
+    _, ncomps_after = morph.label(binary)
+    LOG.debug('black components before/after denoising (maxsize=%d): %d/%d',
+              maxsize, ncomps_before, ncomps_after)
+    return array2pil(1 - binary)
+
+# to be refactored into core:
+# inspired by ocrolib.compute_lines
+def resegment(mask_image, labels):
+    """Shrink a mask to the largest component of a segmentation.
+    
+    Given a PIL.Image of a mask and a label array for the region,
+    find the label with the largest area within the mask,
+    and reduce the mask to that.
+    
+    Return a PIL.Image.
+    """
+    mask = np.array(pil2array(mask_image), np.uint8)
+    #DSAVE('mask', mask)
+    #DSAVE('labels', labels)
+    #DSAVE('mask*labels', mask*labels)
+    objects = morph.find_objects(mask * labels)
+    max_count, max_mask = 0, mask
+    for slices in objects:
+        if not slices: continue
+        if (sl.dim1(slices) < 2 * 20 or
+            sl.dim0(slices) < 20): continue
+        # identify largest label in slice:
+        count = np.bincount(labels[slices].flat)
+        label = np.argmax(count)
+        count = np.amax(count)
+        if not count: continue
+        if count > max_count:
+            max_count = count
+            #max_mask = labels == label
+            # avoid increasing margin when recropping:
+            max_mask = mask * (labels == label)
+    #DSAVE('max_mask', max_mask)
+    LOG.debug('black pixels before/after resegment (nlabels=%d): %d/%d',
+              len(objects),
+              np.count_nonzero(mask * labels),
+              np.count_nonzero(max_mask))
+    return array2pil(max_mask)
+
+# to be refactored into core (as function in ocrd_utils):
+def polygon_mask(image, coordinates):
+    mask = Image.new('L', image.size, 0)
+    ImageDraw.Draw(mask).polygon(coordinates, outline=1, fill=255)
+    return mask
+
+# to be refactored into core (as function in ocrd_utils):
+def rotate_polygon(coordinates, angle, orig={'x': 0, 'y': 0}):
+    # if the region image has been rotated, we must also
+    # rotate the coordinates of the line
+    # (which relate to the top page image)
+    # in the same direction but with inverse transformation
+    # matrix (i.e. passive rotation), and
+    # (since the region was rotated around its center,
+    #  but our coordinates are now relative to the top left)
+    # by first translating to center of region, then
+    # rotating around that center, and translating back:
+    # point := (point - region_center) * region_rotation + region_center
+    # moreover, since rotation has reshaped/expanded the image,
+    # the line coordinates must be offset by those additional pixels:
+    # point := point + 0.5 * (new_region_size - old_region_size)
+    angle = np.deg2rad(angle)
+    # active rotation:  [[cos, -sin], [sin, cos]]
+    # passive rotation: [[cos, sin], [-sin, cos]] (inverse)
+    return [(orig['x']
+             + (x - orig['x'])*np.cos(angle)
+             + (y - orig['y'])*np.sin(angle),
+             orig['y']
+             - (x - orig['x'])*np.sin(angle)
+             + (y - orig['y'])*np.cos(angle))
+            for x, y in coordinates]
+
+# to be refactored into core (as method of ocrd.workspace.Workspace):
+def image_from_page(workspace, page,
+                    page_image,
+                    page_id):
+    """Extract the Page image from the workspace.
+    
+    Given a PIL.Image of the page, `page_image`,
+    and the Page object logically associated with it, `page`,
+    extract its PIL.Image from AlternativeImage (if it exists),
+    or via cropping from `page_image` (if a Border exists),
+    or by just returning `page_image` (otherwise).
+    
+    When using AlternativeImage, if the resulting page image
+    is larger than the annotated page, then pass down the page's
+    box coordinates with an offset of half the width/height difference.
+    
+    Return the extracted image, and the page's box coordinates,
+    relative to the source image (for passing down).
+    """
+    page_xywh = {'x': 0,
+                 'y': 0,
+                 'w': page_image.width,
+                 'h': page_image.height}
+    # FIXME: remove PrintSpace here as soon as GT abides by the PAGE standard:
+    border = page.get_Border() or page.get_PrintSpace()
+    if border and border.get_Coords():
+        LOG.debug("Using explictly set page border '%s' for page '%s'",
+                  border.get_Coords().points, page_id)
+        page_xywh = xywh_from_points(border.get_Coords().points)
+    
+    alternative_image = page.get_AlternativeImage()
+    if alternative_image:
+        # (e.g. from page-level cropping, binarization, deskewing or despeckling)
+        # assumes implicit cropping (i.e. page_xywh has been applied already)
+        LOG.debug("Using AlternativeImage %d (%s) for page '%s'",
+                  len(alternative_image), alternative_image[-1].get_comments(),
+                  page_id)
+        page_image = workspace.resolve_image_as_pil(
+            alternative_image[-1].get_filename())
+    elif border:
+        page_image = page_image.crop(
+            box=(page_xywh['x'],
+                 page_xywh['y'],
+                 page_xywh['x'] + page_xywh['w'],
+                 page_xywh['y'] + page_xywh['h']))
+        # FIXME: mask away all GraphicRegion, SeparatorRegion etc which
+        # could overlay any text regions
+    # subtract offset from any increase in binary region size over source:
+    page_xywh['x'] -= 0.5 * max(0, page_image.width  - page_xywh['w'])
+    page_xywh['y'] -= 0.5 * max(0, page_image.height - page_xywh['h'])
+    return page_image, page_xywh
+
+# to be refactored into core (as method of ocrd.workspace.Workspace):
+def image_from_region(workspace, region,
+                      page_image, page_xywh,
+                      page_id):
+    """Extract the TextRegion image from a Page image.
+    
+    Given a PIL.Image of the page, `page_image`,
+    and its coordinates relative to the border, `page_xywh`,
+    and a TextRegion object logically contained in it, `region`,
+    extract its PIL.Image from AlternativeImage (if it exists),
+    or via cropping from `page_image`.
+    
+    When cropping, respect any angle annotated for the region
+    (from deskewing) by rotating the cropped image, respectively.
+    Regardless, if the resulting region image is larger than
+    the annotated region, pass down the region's box coordinates
+    with an offset of half the width/height difference.
+    
+    Return the extracted image, and the region's box coordinates,
+    relative to the page image (for passing down).
+    """
+    region_xywh = xywh_from_points(region.get_Coords().points)
+    # region angle: PAGE orientation is defined clockwise,
+    # whereas PIL/ndimage rotation is in mathematical direction:
+    region_xywh['angle'] = -(region.get_orientation() or 0)
+    alternative_image = region.get_AlternativeImage()
+    if alternative_image:
+        # (e.g. from region-level cropping, binarization, deskewing or despeckling)
+        LOG.debug("Using AlternativeImage %d (%s) for page '%s' region '%s'",
+                  len(alternative_image), alternative_image[-1].get_comments(),
+                  page_id, region.id)
+        region_image = workspace.resolve_image_as_pil(
+            alternative_image[-1].get_filename())
+    else:
+        region_image = page_image.crop(
+            box=(region_xywh['x'] - page_xywh['x'],
+                 region_xywh['y'] - page_xywh['y'],
+                 region_xywh['x'] - page_xywh['x'] + region_xywh['w'],
+                 region_xywh['y'] - page_xywh['y'] + region_xywh['h']))
+        if region_xywh['angle']:
+            LOG.info("About to rotate page '%s' region '%s' by %.1f°",
+                      page_id, region.id, region_xywh['angle'])
+            region_image = region_image.rotate(region_xywh['angle'],
+                                               expand=True,
+                                               #resample=Image.BILINEAR,
+                                               fillcolor='white')
+    # subtract offset from any increase in binary region size over source:
+    region_xywh['x'] -= 0.5 * max(0, region_image.width  - region_xywh['w'])
+    region_xywh['y'] -= 0.5 * max(0, region_image.height - region_xywh['h'])
+    return region_image, region_xywh
+
+# to be refactored into core (as method of ocrd.workspace.Workspace):
+def image_from_line(workspace, line,
+                    region_image, region_xywh,
+                    region_id, page_id):
+    """Extract the TextLine image from a TextRegion image.
+    
+    Given a PIL.Image of the region, `region_image`,
+    and its coordinates relative to the page, `region_xywh`,
+    and a TextLine object logically contained in it, `line`,
+    extract its PIL.Image from AlternativeImage (if it exists),
+    or via cropping from `region_image`.
+    
+    When cropping, respect any angle annotated for the region
+    (from deskewing) by compensating the line coordinates in
+    an inverse transformation (translation to center, rotation,
+    re-translation). Also, mind the difference between annotated
+    and actual size of the region (usually from deskewing), by
+    a respective offset into the image. Cropping uses a polygon
+    mask (not just the rectangle).
+    
+    If passed an optional labelling for the region, `segmentation`,
+    the mask is shrinked further to the largest overlapping line
+    label, which avoids seeing ascenders from lines below, and
+    descenders from lines above `line`.
+    
+    If the resulting line image is larger than the annotated line,
+    pass down the line's box coordinates with an offset of half
+    the width/height difference.
+    
+    Return the extracted image, and the line's box coordinates,
+    relative to the region image (for passing down).
+    """
+    line_points = line.get_Coords().points
+    line_xywh = xywh_from_points(line_points)
+    line_polygon = [(x - region_xywh['x'],
+                     y - region_xywh['y'])
+                    for x, y in polygon_from_points(line_points)]
+    alternative_image = line.get_AlternativeImage()
+    if alternative_image:
+        # (e.g. from line-level cropping, deskewing or despeckling)
+        LOG.debug("Using AlternativeImage %d (%s) for page '%s' region '%s' line '%s'",
+                  len(alternative_image), alternative_image[-1].get_comments(),
+                  page_id, region_id, line.id)
+        line_image = workspace.resolve_image_as_pil(
+            alternative_image[-1].get_filename())
+    else:
+        # create a mask from the line polygon:
+        line_polygon = rotate_polygon(line_polygon,
+                                      region_xywh['angle'],
+                                      orig={'x': 0.5 * region_image.width,
+                                            'y': 0.5 * region_image.height})
+        line_mask = polygon_mask(region_image, line_polygon)
+        if region_xywh['w'] > 100 and region_xywh['h'] > 100:
+            # modify mask from (ad-hoc) line segmentation of region
+            # (shrink to largest label spread in that area):
+            try:
+                region_array = pil2array(region_image)
+                region_bin, _ = binarize(region_array, maxskew=0)
+                region_labels = compute_line_labels(region_bin)
+                line_mask = resegment(line_mask, region_labels)
+            except Exception as err:
+                LOG.warning('cannot line-segment region "%s": %s', region_id, err)
+        # create a background image from its median color
+        # (in case it has not been binarized yet):
+        region_array = np.asarray(region_image)
+        background = np.median(region_array, axis=[0, 1], keepdims=True)
+        region_array = np.broadcast_to(background.astype(np.uint8), region_array.shape)
+        line_image = Image.fromarray(region_array)
+        line_image.paste(region_image, mask=line_mask)
+        # recrop into a line:
+        left, upper, right, lower = line_mask.getbbox()
+        # keep upper/lower, regardless of h (no vertical padding)
+        # pad left/right if target width w is larger:
+        margin_x = (line_xywh['w'] - right + left) // 2
+        left = max(0, left - margin_x)
+        right = min(line_mask.width, left + line_xywh['w'])
+        line_image = line_image.crop(box=(left, upper, right, lower))
+    # subtract offset from any increase in binary line size over source:
+    line_xywh['x'] -= 0.5 * max(0, line_image.width  - line_xywh['w'])
+    line_xywh['y'] -= 0.5 * max(0, line_image.height - line_xywh['h'])
+    return line_image, line_xywh
+                
+# to be refactored into core (as method of ocrd.workspace.Workspace):
+def save_image_file(workspace, image,
+                    file_id,
+                    page_id=None,
+                    file_grp='OCR-D-IMG', # or -BIN?
+                    format='PNG',
+                    force=True):
+    """Store and reference an image as file into the workspace.
+    
+    Given a PIL.Image `image`, and an ID `file_id` to use in METS,
+    store the image under the fileGrp `file_grp` and physical page
+    `page_id` into the workspace (in a file name based on
+    the `file_grp`, `file_id` and `format` extension).
+    
+    Return the (absolute) path of the created file.
+    """
+    image_bytes = io.BytesIO()
+    image.save(image_bytes, format=format)
+    file_path = os.path.join(file_grp,
+                             file_id + '.' + format.lower())
+    out = workspace.add_file(
+        ID=file_id,
+        file_grp=file_grp,
+        pageId=page_id,
+        local_filename=file_path,
+        mimetype='image/' + format.lower(),
+        content=image_bytes.getvalue(),
+        force=force)
+    LOG.info('created file ID: %s, file_grp: %s, path: %s',
+             file_id, file_grp, out.local_filename)
+    return file_path

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -75,23 +75,22 @@ class OcropyDeskew(Processor):
                 LOG.warning('Page "%s" contains no text regions', page_id)
             for region in regions:
                 if region.get_orientation():
-                    LOG.error('Page "%s" region "%s" already has non-zero orientation: %.1f',
-                              page_id, region.id, region.get_orientation())
+                    LOG.error('Region "%s" already has non-zero orientation: %.1f',
+                              region.id, region.get_orientation())
                     # it would be dangerous to proceed here, because
                     # the angle could already have been applied to the image
                     # and our new estimate would (or would not) be additive
                     continue
                 # process region:
                 region_image, region_xywh = image_from_region(
-                    self.workspace, region, page_image, page_xywh, page_id)
-                LOG.info("About to deskew page '%s' region '%s'",
-                         page_id, region.id)
+                    self.workspace, region, page_image, page_xywh)
+                LOG.info("About to deskew region '%s'", region.id)
                 angle = deskew(region_image, maxskew=maxskew)
                 # region angle: PAGE orientation is defined clockwise,
                 # whereas PIL/ndimage rotation is in mathematical direction:
                 region.set_orientation(-angle)
-                LOG.info("Found angle for page '%s' region '%s': %.1f",
-                         page_id, region.id, angle)
+                LOG.info("Found angle for region '%s': %.1f",
+                         region.id, angle)
             
             # update METS (add the PAGE file):
             file_id = input_file.ID.replace(self.input_file_grp,

--- a/ocrd_cis/ocropy/deskew.py
+++ b/ocrd_cis/ocropy/deskew.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import
+
+import sys
+import os.path
+import io
+import warnings
+import cv2
+import numpy as np
+from scipy.ndimage import filters, interpolation, measurements, morphology
+from scipy import stats
+from PIL import Image
+
+from ocrd_utils import getLogger, concat_padded, xywh_from_points, points_from_x0y0x1y1
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import to_xml, AlternativeImageType, CoordsType
+from ocrd import Processor
+from ocrd_utils import MIMETYPE_PAGE
+
+from .. import get_ocrd_tool
+from . import common
+from .common import (
+    LOG,
+    image_from_page,
+    image_from_region,
+    image_from_line,
+    save_image_file,
+    pil2array, array2pil)
+
+#sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+LOG = getLogger('processor.OcropyDeskew')
+
+def deskew(pil_image, maxskew=2):
+    array = pil2array(pil_image)
+    _, angle = common.binarize(array, maxskew=maxskew)
+    return angle
+
+class OcropyDeskew(Processor):
+
+    def __init__(self, *args, **kwargs):
+        self.ocrd_tool = get_ocrd_tool()
+        kwargs['ocrd_tool'] = self.ocrd_tool['tools']['ocrd-cis-ocropy-binarize']
+        kwargs['version'] = self.ocrd_tool['version']
+        super(OcropyDeskew, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Deskew the regions of the workspace.
+        
+        Open and deserialise PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the TextRegion level.
+        
+        Next, for each file, crop each region image according to the layout
+        annotation (via coordinates into the higher-level image, or from the
+        alternative image), and determine the threshold for binarization and
+        the deskewing angle of the region (up to `maxskew`). Annotate the
+        angle in the region.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        maxskew = self.parameter['maxskew']
+        
+        for (n, input_file) in enumerate(self.input_files):
+            LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
+            
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page_id = pcgts.pcGtsId or input_file.pageId # (PageType has no id)
+            page = pcgts.get_Page()
+            page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
+            # process page:
+            page_image, page_xywh = image_from_page(
+                self.workspace, page, page_image, page_id)
+            
+            regions = page.get_TextRegion()
+            if not regions:
+                LOG.warning('Page "%s" contains no text regions', page_id)
+            for region in regions:
+                if region.get_orientation():
+                    LOG.error('Page "%s" region "%s" already has non-zero orientation: %.1f',
+                              page_id, region.id, region.get_orientation())
+                    # it would be dangerous to proceed here, because
+                    # the angle could already have been applied to the image
+                    # and our new estimate would (or would not) be additive
+                    continue
+                # process region:
+                region_image, region_xywh = image_from_region(
+                    self.workspace, region, page_image, page_xywh, page_id)
+                LOG.info("About to deskew page '%s' region '%s'",
+                         page_id, region.id)
+                angle = deskew(region_image, maxskew=maxskew)
+                # region angle: PAGE orientation is defined clockwise,
+                # whereas PIL/ndimage rotation is in mathematical direction:
+                region.set_orientation(-angle)
+                LOG.info("Found angle for page '%s' region '%s': %.1f",
+                         page_id, region.id, angle)
+            
+            # update METS (add the PAGE file):
+            file_id = input_file.ID.replace(self.input_file_grp,
+                                            self.output_file_grp)
+            file_path = os.path.join(self.output_file_grp,
+                                     file_id + '.xml')
+            out = self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                local_filename=file_path,
+                mimetype=MIMETYPE_PAGE,
+                content=to_xml(pcgts))
+            LOG.info('created file ID: %s, file_grp: %s, path: %s',
+                     file_id, self.output_file_grp, out.local_filename)
+    

--- a/ocrd_cis/ocropy/dewarp.py
+++ b/ocrd_cis/ocropy/dewarp.py
@@ -101,7 +101,7 @@ class OcropyDewarp(Processor):
             for region in regions:
                 # process region:
                 region_image, region_xywh = image_from_region(
-                    self.workspace, region, page_image, page_xywh, page_id)
+                    self.workspace, region, page_image, page_xywh)
                 
                 lines = region.get_TextLine()
                 if not lines:
@@ -109,8 +109,7 @@ class OcropyDewarp(Processor):
                 for line in lines:
                     # process line:
                     line_image, _ = image_from_line(
-                        self.workspace, line, region_image, region_xywh,
-                        region.id, page_id)
+                        self.workspace, line, region_image, region_xywh)
                     
                     LOG.info("About to dewarp page '%s' region '%s' line '%s'",
                              page_id, region.id, line.id)

--- a/ocrd_cis/ocropy/dewarp.py
+++ b/ocrd_cis/ocropy/dewarp.py
@@ -1,0 +1,150 @@
+from __future__ import absolute_import
+
+import sys
+import os.path
+import numpy as np
+
+from ocrd_utils import getLogger, concat_padded
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import to_xml, AlternativeImageType
+from ocrd import Processor
+from ocrd_utils import MIMETYPE_PAGE
+
+from .. import get_ocrd_tool
+from . import common
+from .ocrolib import lineest
+from .common import (
+    LOG,
+    image_from_page,
+    image_from_region,
+    image_from_line,
+    save_image_file,
+    pil2array, array2pil,
+    check_line, check_page,
+    compute_line_labels)
+    
+#sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+LOG = getLogger('processor.OcropyDewarp')
+FILEGRP_IMG = 'OCR-D-IMG-DEWARP'
+
+# from ocropus-dewarp, but without resizing
+def dewarp(image, lnorm, check=True):
+    line = pil2array(image)
+    
+    if np.prod(line.shape) == 0:
+        raise Exception('image dimensions are zero')
+    if np.amax(line) == np.amin(line):
+        raise Exception('image is blank')
+    
+    temp = np.amax(line)-line # inverse, zero-closed
+    if check:
+        report = check_line(temp)
+        if report:
+            raise Exception(report)
+    
+    temp = temp * 1.0 / np.amax(temp) # normalized
+    lnorm.setHeight(image.height) # keep line size
+    lnorm.measure(temp) # find centerline
+    #line = lnorm.dewarp(line, cval=np.amax(line))
+    line = lnorm.normalize(line, cval=np.amax(line))
+    
+    return array2pil(line)
+
+class OcropyDewarp(Processor):
+
+    def __init__(self, *args, **kwargs):
+        self.ocrd_tool = get_ocrd_tool()
+        kwargs['ocrd_tool'] = self.ocrd_tool['tools']['ocrd-cis-ocropy-dewarp']
+        kwargs['version'] = self.ocrd_tool['version']
+        super(OcropyDewarp, self).__init__(*args, **kwargs)
+
+        # defaults from ocrolib.lineest:
+        range_ = self.parameter['range']
+        self.lnorm = lineest.CenterNormalizer(params=(range_, 1.0, 0.3))
+
+    def process(self):
+        """Dewarp the lines of the workspace.
+        
+        Open and deserialise PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the TextLine level.
+        
+        Next, get each line image according to the layout annotation (from
+        the alternative image of the line, or by cropping via coordinates
+        into the higher-level image), and dewarp it (without resizing).
+        Export the result as an image file.
+        
+        Add the new image file to the workspace with a fileGrp USE equal
+        `OCR-D-IMG-DEWARP` and an ID based on input file and input element.
+        
+        Reference each new image in the AlternativeImage of the element.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        
+        for (n, input_file) in enumerate(self.input_files):
+            LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
+            #file_id = concat_padded(FILEGRP_IMG, n)
+            file_id = input_file.ID.replace(self.input_file_grp, FILEGRP_IMG)
+            
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page_id = pcgts.pcGtsId or input_file.pageId # (PageType has no id)
+            page = pcgts.get_Page()
+            page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
+            # process page:
+            page_image, page_xywh = image_from_page(
+                self.workspace, page, page_image, page_id)
+            
+            regions = page.get_TextRegion()
+            if not regions:
+                LOG.warning('Page "%s" contains no text regions', page_id)
+            for region in regions:
+                # process region:
+                region_image, region_xywh = image_from_region(
+                    self.workspace, region, page_image, page_xywh, page_id)
+                
+                lines = region.get_TextLine()
+                if not lines:
+                    LOG.warning('Region %s contains no text lines', region.id)
+                for line in lines:
+                    # process line:
+                    line_image, _ = image_from_line(
+                        self.workspace, line, region_image, region_xywh,
+                        region.id, page_id)
+                    
+                    LOG.info("About to dewarp page '%s' region '%s' line '%s'",
+                             page_id, region.id, line.id)
+                    try:
+                        dew_image = dewarp(line_image, self.lnorm, check=True)
+                    except Exception as err:
+                        LOG.error('error dewarping line "%s": %s', line.id, err)
+                        continue
+                    # update METS (add the image file):
+                    file_path = save_image_file(
+                        self.workspace,
+                        dew_image,
+                        file_id + '_' + region.id + '_' + line.id,
+                        page_id=input_file.pageId,
+                        file_grp=FILEGRP_IMG)
+                    # update PAGE (reference the image file):
+                    alternative_image = line.get_AlternativeImage()
+                    line.add_AlternativeImage(AlternativeImageType(
+                        filename=file_path,
+                        comments=(alternative_image[-1].get_comments() + ','
+                                  if alternative_image else '') + 'dewarped'))
+            
+            # update METS (add the PAGE file):
+            file_id = input_file.ID.replace(self.input_file_grp,
+                                            self.output_file_grp)
+            file_path = os.path.join(self.output_file_grp,
+                                     file_id + '.xml')
+            out = self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                local_filename=file_path,
+                mimetype=MIMETYPE_PAGE,
+                content=to_xml(pcgts))
+            LOG.info('created file ID: %s, file_grp: %s, path: %s',
+                     file_id, self.output_file_grp, out.local_filename)
+    

--- a/ocrd_cis/ocropy/ocrolib/common.py
+++ b/ocrd_cis/ocropy/ocrolib/common.py
@@ -297,7 +297,11 @@ def iulib_page_iterator(files):
         yield image,fname
 
 def norm_max(a):
-    return a/amax(a)
+    norm = amax(a) # or nanmax?
+    if norm:
+        return a/norm
+    else:
+        return a # or 0?
 
 def pad_by(image,r,dtype=None):
     """Symmetrically pad the image by the given amount.

--- a/ocrd_cis/ocropy/ocrolib/psegutils.py
+++ b/ocrd_cis/ocropy/ocrolib/psegutils.py
@@ -1,0 +1,238 @@
+from __future__ import print_function
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from scipy.ndimage import filters,interpolation
+
+from .toplevel import *
+from . import sl,morph
+
+def B(a):
+    if a.dtype==np.dtype('B'): return a
+    return np.array(a,'B')
+
+class record:
+    def __init__(self,**kw): self.__dict__.update(kw)
+
+def blackout_images(image,ticlass):
+    """Takes a page image and a ticlass text/image classification image and replaces
+    all regions tagged as 'image' with rectangles in the page image.  The page image
+    is modified in place.  All images are iulib arrays."""
+    rgb = ocropy.intarray()
+    ticlass.textImageProbabilities(rgb,image)
+    r = ocropy.bytearray()
+    g = ocropy.bytearray()
+    b = ocropy.bytearray()
+    ocropy.unpack_rgb(r,g,b,rgb)
+    components = ocropy.intarray()
+    components.copy(g)
+    n = ocropy.label_components(components)
+    print("[note] number of image regions", n)
+    tirects = ocropy.rectarray()
+    ocropy.bounding_boxes(tirects,components)
+    for i in range(1,tirects.length()):
+        r = tirects.at(i)
+        ocropy.fill_rect(image,r,0)
+        r.pad_by(-5,-5)
+        ocropy.fill_rect(image,r,255)
+        
+def binary_objects(binary):
+    labels,n = morph.label(binary)
+    objects = morph.find_objects(labels)
+    return objects
+
+def estimate_scale(binary):
+    objects = binary_objects(binary)
+    bysize = sorted(objects,key=sl.area)
+    scalemap = np.zeros(binary.shape)
+    for o in bysize:
+        if np.amax(scalemap[o])>0: continue
+        scalemap[o] = sl.area(o)**0.5
+    scale = np.median(scalemap[(scalemap>3)&(scalemap<100)])
+    return scale
+
+def compute_boxmap(binary,scale,threshold=(.5,4),dtype='i'):
+    objects = binary_objects(binary)
+    bysize = sorted(objects,key=sl.area)
+    boxmap = np.zeros(binary.shape,dtype)
+    for o in bysize:
+        if sl.area(o)**.5<threshold[0]*scale: continue
+        if sl.area(o)**.5>threshold[1]*scale: continue
+        boxmap[o] = 1
+    return boxmap
+
+def compute_lines(segmentation,scale):
+    """Given a line segmentation map, computes a list
+    of tuples consisting of 2D slices and masked images."""
+    lobjects = morph.find_objects(segmentation)
+    lines = []
+    for i,o in enumerate(lobjects):
+        if o is None: continue
+        if sl.dim1(o)<2*scale or sl.dim0(o)<scale: continue
+        mask = (segmentation[o]==i+1)
+        if np.amax(mask)==0: continue
+        result = record()
+        result.label = i+1
+        result.bounds = o
+        result.mask = mask
+        lines.append(result)
+    return lines
+
+def pad_image(image,d,cval=np.inf):
+    result = np.ones(np.array(image.shape)+2*d)
+    result[:,:] = np.amax(image) if cval==np.inf else cval
+    result[d:-d,d:-d] = image
+    return result
+
+@checks(ARANK(2),int,int,int,int,mode=str,cval=True,_=GRAYSCALE)
+def extract(image,y0,x0,y1,x1,mode='nearest',cval=0):
+    h,w = image.shape
+    ch,cw = y1-y0,x1-x0
+    y,x = np.clip(y0,0,max(h-ch,0)),np.clip(x0,0,max(w-cw, 0))
+    sub = image[y:y+ch,x:x+cw]
+    # print("extract", image.dtype, image.shape)
+    try:
+        r = interpolation.shift(sub,(y-y0,x-x0),mode=mode,cval=cval,order=0)
+        if cw > w or ch > h:
+            pady0, padx0 = max(-y0, 0), max(-x0, 0)
+            r = interpolation.affine_transform(r, np.eye(2), offset=(pady0, padx0), cval=1, output_shape=(ch, cw))
+        return r
+
+    except RuntimeError:
+        # workaround for platform differences between 32bit and 64bit
+        # scipy.ndimage
+        dtype = sub.dtype
+        sub = np.array(sub,dtype='float64')
+        sub = interpolation.shift(sub,(y-y0,x-x0),mode=mode,cval=cval,order=0)
+        sub = np.array(sub,dtype=dtype)
+        return sub
+
+@checks(ARANK(2),True,pad=int,expand=int,_=GRAYSCALE)
+def extract_masked(image,linedesc,pad=5,expand=0):
+    """Extract a subimage from the image using the line descriptor.
+    A line descriptor consists of bounds and a mask."""
+    y0,x0,y1,x1 = [int(x) for x in [linedesc.bounds[0].start,linedesc.bounds[1].start, \
+                  linedesc.bounds[0].stop,linedesc.bounds[1].stop]]
+    if pad>0:
+        mask = pad_image(linedesc.mask,pad,cval=0)
+    else:
+        mask = linedesc.mask
+    line = extract(image,y0-pad,x0-pad,y1+pad,x1+pad)
+    if expand>0:
+        mask = filters.maximum_filter(mask,(expand,expand))
+    line = np.where(mask,line,np.amax(line))
+    return line
+
+def reading_order(lines,highlight=None,debug=0):
+    """Given the list of lines (a list of 2D slices), computes
+    the partial reading order.  The output is a binary 2D array
+    such that order[i,j] is true if line i comes before line j
+    in reading order."""
+    order = np.zeros((len(lines),len(lines)),'B')
+    def x_overlaps(u,v):
+        return u[1].start<v[1].stop and u[1].stop>v[1].start
+    def above(u,v):
+        return u[0].start<v[0].start
+    def left_of(u,v):
+        return u[1].stop<v[1].start
+    def separates(w,u,v):
+        if w[0].stop<min(u[0].start,v[0].start): return 0
+        if w[0].start>max(u[0].stop,v[0].stop): return 0
+        if w[1].start<u[1].stop and w[1].stop>v[1].start: return 1
+    if highlight is not None:
+        plt.clf()
+        plt.title("highlight")
+        plt.imshow(binary)
+        plt.ginput(1,debug)
+    for i,u in enumerate(lines):
+        for j,v in enumerate(lines):
+            if x_overlaps(u,v):
+                if above(u,v):
+                    order[i,j] = 1
+            else:
+                if [w for w in lines if separates(w,u,v)]==[]:
+                    if left_of(u,v): order[i,j] = 1
+            if j==highlight and order[i,j]:
+                print((i, j), end=' ')
+                y0,x0 = sl.center(lines[i])
+                y1,x1 = sl.center(lines[j])
+                plt.plot([x0,x1+200],[y0,y1])
+    if highlight is not None:
+        print()
+        plt.ginput(1,debug)
+    return order
+
+def topsort(order):
+    """Given a binary array defining a partial order (o[i,j]==True means i<j),
+    compute a topological sort.  This is a quick and dirty implementation
+    that works for up to a few thousand elements."""
+    n = len(order)
+    visited = np.zeros(n)
+    L = []
+    def visit(k):
+        if visited[k]: return
+        visited[k] = 1
+        for l in find(order[:,k]):
+            visit(l)
+        L.append(k)
+    for k in range(n):
+        visit(k)
+    return L #[::-1]
+
+def find(condition):
+    "Return the indices where ravel(condition) is true"
+    res, = np.nonzero(np.ravel(condition))
+    return res
+
+def show_lines(image,lines,lsort):
+    """Overlays the computed lines on top of the image, for debugging
+    purposes."""
+    ys,xs = [],[]
+    plt.clf()
+    plt.cla()
+    plt.imshow(image)
+    for i in range(len(lines)):
+        l = lines[lsort[i]]
+        y,x = sl.center(l.bounds)
+        xs.append(x)
+        ys.append(y)
+        o = l.bounds
+        r = mpatches.Rectangle((o[1].start,o[0].start),edgecolor='r',fill=0,width=sl.dim1(o),height=sl.dim0(o))
+        plt.gca().add_patch(r)
+    h,w = image.shape
+    plt.ylim(h,0)
+    plt.xlim(0,w)
+    plt.plot(xs,ys)
+
+@obsolete
+def read_gray(fname):
+    image = plt.imread(fname)
+    if image.ndim==3: image = mean(image,2)
+    return image
+
+@obsolete
+def read_binary(fname):
+    image = plt.imread(fname)
+    if image.ndim==3: image = np.mean(image,2)
+    image -= np.amin(image)
+    image /= np.amax(image)
+    assert sum(image<0.01)+sum(image>0.99)>0.99*np.prod(image.shape),"input image is not binary"
+    binary = 1.0*(image<0.5)
+    return binary
+
+@obsolete
+def rgbshow(r,g,b=None,gn=1,cn=0,ab=0,**kw):
+    """Small function to display 2 or 3 images as RGB channels."""
+    if b is None: b = np.zeros(r.shape)
+    combo = np.transpose(array([r,g,b]),axes=[1,2,0])
+    if cn:
+        for i in range(3):
+            combo[:,:,i] /= max(np.abs(np.amin(combo[:,:,i])),np.abs(np.amax(combo[:,:,i])))
+    elif gn:
+        combo /= max(np.abs(np.amin(combo)),np.abs(np.amax(combo)))
+    if ab:
+        combo = np.abs(combo)
+    if np.amin(combo)<0: print("warning: values less than zero")
+    plt.imshow(np.clip(combo,0,1),**kw)
+

--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -140,7 +140,7 @@ class OcropyRecognize(Processor):
             regions = page.get_TextRegion()
             if not regions:
                 LOG.warning("Page '%s' contains no text regions", page_id)
-            self.process_regions(regions, maxlevel, page_image, page_xywh, page_id)
+            self.process_regions(regions, maxlevel, page_image, page_xywh)
             
             # update METS (add the PAGE file):
             file_id = input_file.ID.replace(self.input_file_grp,
@@ -157,31 +157,30 @@ class OcropyRecognize(Processor):
             LOG.info('created file ID: %s, file_grp: %s, path: %s',
                      file_id, self.output_file_grp, out.local_filename)
 
-    def process_regions(self, regions, maxlevel, page_image, page_xywh, page_id):
+    def process_regions(self, regions, maxlevel, page_image, page_xywh):
         edits = 0
         lengs = 0
         for region in regions:
             region_image, region_xywh = image_from_region(
-                self.workspace, region, page_image, page_xywh, page_id)
+                self.workspace, region, page_image, page_xywh)
             
             LOG.info("Recognizing text in region '%s'", region.id)
             textlines = region.get_TextLine()
             if not textlines:
                 LOG.warning("Region '%s' contains no text lines", region.id)
             else:
-                edits_, lengs_ = self.process_lines(textlines, maxlevel, region_image, region_xywh,
-                                                    region.id, page_id)
+                edits_, lengs_ = self.process_lines(textlines, maxlevel, region_image, region_xywh)
                 edits += edits_
                 lengs += lengs_
         if lengs > 0:
             LOG.info('CER: %.1f%%', 100.0 * edits / lengs)
 
-    def process_lines(self, textlines, maxlevel, region_image, region_xywh, region_id, page_id):
+    def process_lines(self, textlines, maxlevel, region_image, region_xywh):
         edits = 0
         lengs = 0
         for line in textlines:
             line_image, line_xywh = image_from_line(
-                self.workspace, line, region_image, region_xywh, region_id, page_id)
+                self.workspace, line, region_image, region_xywh)
             
             LOG.info("Recognizing text in line '%s'", line.id)
             if line.get_TextEquiv():

--- a/ocrd_cis/ocropy/recognize.py
+++ b/ocrd_cis/ocropy/recognize.py
@@ -1,214 +1,41 @@
 from __future__ import absolute_import
 
-from ocrd_cis.ocropy.ocrolib import lstm
-from ocrd_cis.ocropy import ocrolib
-from ocrd_cis import get_ocrd_tool
-
 import sys
 import os.path
-import warnings
-import cv2
 import numpy as np
-from scipy.ndimage import filters, interpolation, measurements, morphology
-from scipy import stats
 from PIL import Image
 
 import Levenshtein
-#import kraken.binarization
 
-from ocrd_utils import getLogger, concat_padded, xywh_from_points, points_from_x0y0x1y1
+from ocrd_utils import getLogger, concat_padded, xywh_from_points, points_from_xywh
 from ocrd_modelfactory import page_from_file
 from ocrd_models.ocrd_page import to_xml, TextEquivType, CoordsType, GlyphType, WordType
 from ocrd_models.ocrd_page_generateds import TextStyleType, MetadataItemType, LabelsType, LabelType
 from ocrd import Processor
 from ocrd_utils import MIMETYPE_PAGE
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from .. import get_ocrd_tool
+from .ocrolib import lstm, load_object
+from .common import (
+    LOG,
+    image_from_page,
+    image_from_region,
+    image_from_line,
+    pil2array,
+    check_line)
+
+#sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 LOG = getLogger('processor.OcropyRecognize')
 
-def bounding_box(coord_points):
-    point_list = [[int(p) for p in pair.split(',')]
-                  for pair in coord_points.split(' ')]
-    x_coordinates, y_coordinates = zip(*point_list)
-    return (min(x_coordinates), min(y_coordinates), max(x_coordinates), max(y_coordinates))
-
-
 def resize_keep_ratio(image, baseheight=48):
-    hpercent = (baseheight / float(image.size[1]))
-    wsize = int((float(image.size[0] * float(hpercent))))
+    hpercent = (baseheight / float(image.height))
+    wsize = round(image.width * hpercent)
     image = image.resize((wsize, baseheight), Image.ANTIALIAS)
     return image
 
-# method similar to ocrolib.read_image_gray:
-def pil2array(image):
-    assert isinstance(image, Image.Image), "not a PIL.Image"
-    array = ocrolib.pil2array(image)
-    if array.dtype == np.uint8:
-        array = array / 255.0
-    if array.dtype == np.int8:
-        array = array / 127.0
-    elif array.dtype == np.uint16:
-        array = array / 65536.0
-    elif array.dtype == np.int16:
-        array = array / 32767.0
-    elif np.issubdtype(array.dtype, np.floating):
-        pass
-    else:
-        raise Exception("unknown image type: " + array.dtype)
-    if array.ndim == 3:
-        array = np.mean(array, 2)
-    return array
-
-def array2pil(array):
-    assert isinstance(array, np.ndarray), "not a numpy array"
-    array = np.array(255.0 * array, np.uint8)
-    return ocrolib.array2pil(array)
-
-# methods from ocropy-nlbin:
-def estimate_local_whitelevel(image, zoom=0.5, perc=80, range_=20):
-    '''flatten it by estimating the local whitelevel
-    zoom for page background estimation, smaller=faster, default: %(default)s
-    percentage for filters, default: %(default)s
-    range for filters, default: %(default)s
-    '''
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        m = interpolation.zoom(image, zoom)
-        m = filters.percentile_filter(m, perc, size=(range_, 2))
-        m = filters.percentile_filter(m, perc, size=(2, range_))
-        m = interpolation.zoom(m, 1. / zoom)
-    w, h = np.minimum(np.array(image.shape), np.array(m.shape))
-    flat = np.clip(image[:w, :h] - m[:w, :h] + 1, 0, 1)
-    return flat
-def estimate_skew_angle(image, angles):
-    estimates = []
-    for a in angles:
-        v = np.mean(interpolation.rotate(image, a, order=0, mode='constant'), axis=1)
-        v = np.var(v)
-        estimates.append((v, a))
-    _, a = max(estimates)
-    return a
-def estimate_skew(flat, bignore=0.1, maxskew=2, skewsteps=8):
-    ''' estimate skew angle and rotate'''
-    d0, d1 = flat.shape
-    o0, o1 = int(bignore * d0), int(bignore * d1) # border ignore
-    flat = np.amax(flat) - flat
-    flat -= np.amin(flat)
-    est = flat[o0:d0 - o0, o1:d1 - o1]
-    ma = maxskew
-    ms = int(2 * maxskew * skewsteps)
-    # print(linspace(-ma,ma,ms+1))
-    angle = estimate_skew_angle(est, np.linspace(-ma, ma, ms + 1))
-    flat = interpolation.rotate(flat, angle, mode='constant', reshape=0)
-    flat = np.amax(flat) - flat
-    return flat, angle
-def estimate_thresholds(flat, bignore=0.1, escale=1.0, lo=5, hi=90):
-    '''# estimate low and high thresholds
-    ignore this much of the border for threshold estimation, default: %(default)s
-    scale for estimating a mask over the text region, default: %(default)s
-    lo percentile for black estimation, default: %(default)s
-    hi percentile for white estimation, default: %(default)s
-    '''
-    d0, d1 = flat.shape
-    o0, o1 = int(bignore * d0), int(bignore * d1)
-    est = flat[o0:d0 - o0, o1:d1 - o1]
-    if escale > 0:
-        # by default, we use only regions that contain
-        # significant variance; this makes the percentile
-        # based low and high estimates more reliable
-        e = escale
-        v = est - filters.gaussian_filter(est, e * 20.0)
-        v = filters.gaussian_filter(v ** 2, e * 20.0) ** 0.5
-        v = (v > 0.3 * np.amax(v))
-        v = morphology.binary_dilation(v, structure=np.ones((int(e * 50), 1)))
-        v = morphology.binary_dilation(v, structure=np.ones((1, int(e * 50))))
-        est = est[v]
-    lo = stats.scoreatpercentile(est.ravel(), lo)
-    hi = stats.scoreatpercentile(est.ravel(), hi)
-    return lo, hi
-
-def binarize(pil_image, method='none'):
-    if method == 'none':
-        return pil_image
-    # equivalent to ocropy, but without deskewing:
-    # elif method == 'kraken':
-    #     image = kraken.binarization.nlbin(pil_image)
-    #     return image
-    elif method == 'ocropy':
-        # parameter defaults from ocropy-nlbin:
-        args = {
-            'threshold': 0.5,
-            'zoom': 0.5,
-            'escale': 1.0,
-            'bignore': 0.1,
-            'perc': 80,
-            'range': 20,
-            'maxskew': 2,
-            'lo': 5,
-            'hi': 90,
-            'skewsteps': 8
-        }
-        # process1 from ocropy-nlbin:
-        image = pil2array(pil_image)
-        extreme = (np.sum(image < 0.05) + np.sum(image > 0.95)) * 1.0 / np.prod(image.shape)
-        if extreme > 0.95:
-            comment = "no-normalization"
-            flat = image
-        else:
-            comment = ""
-            # if not, we need to flatten it by estimating the local whitelevel
-            flat = estimate_local_whitelevel(image, args['zoom'], args['perc'], args['range'])
-        if args['maxskew'] > 0:
-            flat, angle = estimate_skew(flat, args['bignore'], args['maxskew'], args['skewsteps'])
-        else:
-            angle = 0
-        lo, hi = estimate_thresholds(flat, args['bignore'], args['escale'], args['lo'], args['hi'])
-        # rescale the image to get the gray scale image
-        flat -= lo
-        flat /= (hi - lo)
-        flat = np.clip(flat, 0, 1)
-        bin = 1 * (flat > args['threshold'])
-        #LOG.debug("binarization: lo-hi (%.2f %.2f) angle %4.1f %s", lo, hi, angle, comment)
-        
-        return array2pil(bin)
-    else:
-        # Convert RGB to OpenCV
-        img = cv2.cvtColor(np.asarray(pil_image), cv2.COLOR_RGB2GRAY)
-
-        if method == 'global':
-            # global thresholding
-            _, th = cv2.threshold(img,127,255,cv2.THRESH_BINARY)
-        elif method == 'otsu':
-            # Otsu's thresholding
-            _, th = cv2.threshold(img,0,255,cv2.THRESH_BINARY+cv2.THRESH_OTSU)
-        elif method == 'gauss-otsu':
-            # Otsu's thresholding after Gaussian filtering
-            blur = cv2.GaussianBlur(img, (5, 5), 0)
-            _, th = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY+cv2.THRESH_OTSU)
-        else:
-            raise Exception('unknown binarization method %s', method)
-        
-        return Image.fromarray(th)
-
-
-def check_line(image):
-    if len(image.shape)==3: return "input image is color image %s"%(image.shape,)
-    if np.mean(image)<np.median(image): return "image may be inverted"
-    h,w = image.shape
-    if h<20: return "image not tall enough for a text line %s"%(image.shape,)
-    if h>200: return "image too tall for a text line %s"%(image.shape,)
-    if w<1.2*h: return "line too short %s"%(image.shape,)
-    if w>4000: return "line too long %s"%(image.shape,)
-    ratio = w*1.0/h
-    _,ncomps = measurements.label(image>np.mean(image))
-    lo = int(0.5*ratio+0.5)
-    hi = int(4*ratio)+1
-    if ncomps<lo: return "too few connected components (got %d, wanted >=%d)"%(ncomps,lo)
-    if ncomps>hi*ratio: return "too many connected components (got %d, wanted <=%d)"%(ncomps,hi)
-    return None
-
-def process1(image, pad, lnorm, network, check=True, dewarp=True):
+# from ocropus-rpred, but without input files and without lineest/dewarping
+def process1(image, pad, network, check=True):
     line = pil2array(image)
 
     raw_line = line.copy()
@@ -217,16 +44,12 @@ def process1(image, pad, lnorm, network, check=True, dewarp=True):
     if np.amax(line) == np.amin(line):
         raise Exception('image is blank')
 
-    # dewarp:
+    # validate:
     temp = np.amax(line)-line
     if check:
         report = check_line(temp)
         if report:
             raise Exception(report)
-    if dewarp:
-        temp = temp * 1.0 / np.amax(temp)
-        lnorm.measure(temp)
-        line = lnorm.normalize(line, cval=np.amax(line))
 
     # recognize:
     line = lstm.prepare_line(line, pad)
@@ -260,121 +83,128 @@ class OcropyRecognize(Processor):
         kwargs['ocrd_tool'] = self.ocrd_tool['tools']['ocrd-cis-ocropy-recognize']
         kwargs['version'] = self.ocrd_tool['version']
         super(OcropyRecognize, self).__init__(*args, **kwargs)
-
-    def process(self):
-        """
-        Performs the (text) recognition.
-        """
-        # print(self.parameter)
-        dewarping = self.parameter['dewarping']
-        binarization = self.parameter['binarization']
-        maxlevel = self.parameter['textequiv_level']
-        if maxlevel not in ['line', 'word', 'glyph']:
-            raise Exception(
-                "currently only implemented at the line/glyph level")
-
-        filepath = os.path.dirname(os.path.abspath(__file__))
-
+        
         ocropydir = os.path.dirname(os.path.abspath(__file__))
-        network = ocrolib.load_object(
+        # from ocropus-rpred:
+        self.network = load_object(
             os.path.join(ocropydir, 'models', self.parameter['model']),
             verbose=1)
-        for x in network.walk():
+        for x in self.network.walk():
             x.postLoad()
-        for x in network.walk():
+        for x in self.network.walk():
             if isinstance(x, lstm.LSTM):
                 x.allocate(5000)
-        lnorm = getattr(network, "lnorm", None)
 
-        pad = 16  # default: 16
+        self.pad = 16 # ocropus-rpred default
+                
+    def process(self):
+        """Recognize lines / words / glyphs of the workspace.
+        
+        Open and deserialise each PAGE input file and its respective image,
+        then iterate over the element hierarchy down to the requested
+        `textequiv_level`. If any layout annotation below the line level
+        already exists, then remove it (regardless of `textequiv_level`).
+        
+        Set up Ocropy to recognise each text line (via coordinates into
+        the higher-level image, or from the alternative image; the image
+        must have been binarised/grayscale-normalised, deskewed and dewarped
+        already). Rescale and pad the image, then recognize.
+        
+        Create new elements below the line level, if necessary.
+        Put text results and confidence values into new TextEquiv at
+        `textequiv_level`, and make the higher levels consistent with that
+        up to the line level (by concatenation joined by whitespace).
+        
+        If a TextLine contained any previous text annotation, then compare
+        that with the new result by aligning characters and computing the
+        Levenshtein distance. Aggregate these scores for each file and print
+        the line-wise and the total character error rates (CER).
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        maxlevel = self.parameter['textequiv_level']
 
         # LOG.info("Using model %s in %s for recognition", model)
         for (n, input_file) in enumerate(self.input_files):
-            LOG.info("INPUT FILE %i / %s", n, input_file)
+            LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
             pcgts = page_from_file(self.workspace.download_file(input_file))
-            pil_image = self.workspace.resolve_image_as_pil(
-                pcgts.get_Page().imageFilename)
-
-            LOG.info("Recognizing text in page '%s'", pcgts.get_pcGtsId())
+            page_id = pcgts.pcGtsId or input_file.pageId # (PageType has no id)
             page = pcgts.get_Page()
-
+            page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
+            # process page:
+            page_image, page_xywh = image_from_page(
+                self.workspace, page, page_image, page_id)
+            
+            LOG.info("Recognizing text in page '%s'", page_id)
             # region, line, word, or glyph level:
             regions = page.get_TextRegion()
             if not regions:
-                LOG.warning("Page contains no text regions")
-
-            args = [lnorm, network, pil_image, filepath, pad, dewarping, binarization]
-
-            self.process_regions(regions, maxlevel, args)
-
-            # Use the input file's basename for the new file
-            # this way the files retain the same basenames.
-            # ID = concat_padded(self.output_file_grp, n)
-            ID = self.output_file_grp + '-' + input_file.basename.replace('.xml', '')
-            LOG.info('creating file id: %s, name: %s, file_grp: %s',
-                     ID, input_file.basename, self.output_file_grp)
+                LOG.warning("Page '%s' contains no text regions", page_id)
+            self.process_regions(regions, maxlevel, page_image, page_xywh, page_id)
+            
+            # update METS (add the PAGE file):
+            file_id = input_file.ID.replace(self.input_file_grp,
+                                            self.output_file_grp)
+            file_path = os.path.join(self.output_file_grp,
+                                     file_id + '.xml')
             out = self.workspace.add_file(
-                ID=ID,
+                ID=file_id,
                 file_grp=self.output_file_grp,
                 pageId=input_file.pageId,
-                basename=input_file.basename,
-                local_filename=os.path.join(self.output_file_grp, input_file.basename),
+                local_filename=file_path,
                 mimetype=MIMETYPE_PAGE,
-                content=to_xml(pcgts),
-            )
-            LOG.info('created file %s', out)
+                content=to_xml(pcgts))
+            LOG.info('created file ID: %s, file_grp: %s, path: %s',
+                     file_id, self.output_file_grp, out.local_filename)
 
-    def process_regions(self, regions, maxlevel, args):
+    def process_regions(self, regions, maxlevel, page_image, page_xywh, page_id):
         edits = 0
         lengs = 0
         for region in regions:
+            region_image, region_xywh = image_from_region(
+                self.workspace, region, page_image, page_xywh, page_id)
+            
             LOG.info("Recognizing text in region '%s'", region.id)
-
             textlines = region.get_TextLine()
             if not textlines:
                 LOG.warning("Region '%s' contains no text lines", region.id)
             else:
-                edits_, lengs_ = self.process_lines(textlines, maxlevel, args)
+                edits_, lengs_ = self.process_lines(textlines, maxlevel, region_image, region_xywh,
+                                                    region.id, page_id)
                 edits += edits_
                 lengs += lengs_
-        LOG.info('CER: %.1f%%', 100.0 * edits / lengs if lengs > 0 else 0.)
+        if lengs > 0:
+            LOG.info('CER: %.1f%%', 100.0 * edits / lengs)
 
-    def process_lines(self, textlines, maxlevel, args):
-        lnorm, network, pil_image, filepath, pad, dewarping, binarization = args
-        
+    def process_lines(self, textlines, maxlevel, region_image, region_xywh, region_id, page_id):
         edits = 0
         lengs = 0
         for line in textlines:
+            line_image, line_xywh = image_from_line(
+                self.workspace, line, region_image, region_xywh, region_id, page_id)
+            
             LOG.info("Recognizing text in line '%s'", line.id)
-            linegt = line.TextEquiv[0].Unicode
+            if line.get_TextEquiv():
+                linegt = line.TextEquiv[0].Unicode
+            else:
+                linegt = ''
             LOG.debug("GT  '%s': '%s'", line.id, linegt)
+            # remove existing annotation below line level:
+            line.set_TextEquiv([])
+            line.set_Word([])
 
-            # get box from points
-            if line.get_Coords().points == '':
-                LOG.warn("empty bounding box at line %s", line.id)
+            if line_image.size[1] < 16:
+                LOG.error("bounding box is too narrow at line %s", line.id)
                 continue
-            box = bounding_box(line.get_Coords().points)
-
-            # crop word from page
-            cropped_image = pil_image.crop(box=box)
-            if cropped_image.size[1] < 32:
-                LOG.warn("bounding box is too narrow at line %s", line.id)
-                continue
-
-            # binarize with Otsu's thresholding after Gaussian filtering
-            bin_image = binarize(cropped_image, method=binarization)
-            #bin_image.save('/tmp/ocrd-cis-ocropy-recognize_%s.bin.png' % line.id)
-
             # resize image to 48 pixel height
-            final_img = resize_keep_ratio(bin_image)
+            final_img = resize_keep_ratio(line_image)
             
             # process ocropy:
             try:
                 linepred, clist, rlist, confidlist = process1(
-                    final_img, pad, lnorm, network,
-                    check=True, dewarp=dewarping)
-            except Exception as e:
-                LOG.error('error processing line "%s": %s', line.id, e)
+                    final_img, self.pad, self.network, check=True)
+            except Exception as err:
+                LOG.error('error processing line "%s": %s', line.id, err)
                 continue
             LOG.debug("OCR '%s': '%s'", line.id, linepred)
             edits += Levenshtein.distance(linepred, linegt)
@@ -405,7 +235,7 @@ class OcropyRecognize(Processor):
                             w_no += 1
             else:
                 word_conf_list = [[0]]
-                word_r_list = [[0, box[2]-box[0]]]
+                word_r_list = [[0, line_xywh['w']]]
 
             # conf for each word
             wordsconf = [(min(x)+max(x))/2 for x in word_conf_list]
@@ -413,37 +243,36 @@ class OcropyRecognize(Processor):
             # conf for the line
             line_conf = (min(wordsconf) + max(wordsconf))/2
 
-            line.replace_TextEquiv_at(0, TextEquivType(
+            line.add_TextEquiv(TextEquivType(
                 Unicode=linepred, conf=line_conf))
 
-            if maxlevel == 'word' or 'glyph':
-                line.Word = []
-                for w_no, w in enumerate(words):
+            if maxlevel in ['word', 'glyph']:
+                for word_no, word_str in enumerate(words):
 
                     # Coords of word
-                    wr = (word_r_list[w_no][0], word_r_list[w_no][-1])
-                    word_bbox = [box[0]+wr[0], box[1], box[2]+wr[1], box[3]]
-
-                    word_id = '%s_word%04d' % (line.id, w_no)
+                    word_xywh = line_xywh.copy()
+                    word_xywh['x'] += word_r_list[word_no][0]
+                    #word_xywh['w'] += word_r_list[word_no][-1]
+                    word_xywh['w'] = word_r_list[word_no][-1] - word_r_list[word_no][0]
+                    word_id = '%s_word%04d' % (line.id, word_no)
                     word = WordType(id=word_id, Coords=CoordsType(
-                        points_from_x0y0x1y1(word_bbox)))
+                        points_from_xywh(word_xywh)))
 
                     line.add_Word(word)
                     word.add_TextEquiv(TextEquivType(
-                        Unicode=w, conf=wordsconf[w_no]))
+                        Unicode=word_str, conf=wordsconf[word_no]))
 
                     if maxlevel == 'glyph':
-                        for glyph_no, g in enumerate(w):
-                            gr = (word_r_list[w_no][glyph_no],
-                                  word_r_list[w_no][glyph_no+1])
-                            glyph_bbox = [box[0]+gr[0],
-                                          box[1], box[2]+gr[1], box[3]]
-
+                        for glyph_no, glyph_str in enumerate(word_str):
+                            glyph_xywh = line_xywh.copy()
+                            glyph_xywh['x'] += word_r_list[word_no][glyph_no]
+                            #glyph_xywh['w'] += word_r_list[word_no][glyph_no+1]
+                            glyph_xywh['w'] = word_r_list[word_no][glyph_no+1] - word_r_list[word_no][glyph_no]
                             glyph_id = '%s_glyph%04d' % (word.id, glyph_no)
                             glyph = GlyphType(id=glyph_id, Coords=CoordsType(
-                                points_from_x0y0x1y1(glyph_bbox)))
+                                points_from_xywh(glyph_xywh)))
 
                             word.add_Glyph(glyph)
                             glyph.add_TextEquiv(TextEquivType(
-                                Unicode=g, conf=word_conf_list[w_no][glyph_no]))
+                                Unicode=glyph_str, conf=word_conf_list[word_no][glyph_no]))
         return edits, lengs

--- a/ocrd_cis/ocropy/resegment.py
+++ b/ocrd_cis/ocropy/resegment.py
@@ -1,0 +1,263 @@
+from __future__ import absolute_import
+
+import sys
+import os.path
+import io
+import numpy as np
+from skimage import measure, draw
+import cv2
+from scipy.ndimage import filters
+
+from ocrd_utils import getLogger
+from ocrd_modelfactory import page_from_file
+from ocrd_models.ocrd_page import to_xml, AlternativeImageType
+from ocrd_models import OcrdExif
+from ocrd import Processor
+from ocrd_utils import MIMETYPE_PAGE
+
+from .. import get_ocrd_tool
+from . import common
+from .ocrolib import midrange
+from .common import (
+    coordinates_of_segment,
+    coordinates_for_segment,
+    image_from_page,
+    image_from_region,
+    image_from_line,
+    pil2array, array2pil,
+    check_line, check_page,
+    # binarize,
+    compute_line_labels,
+    borderclean_bin,
+    points_from_polygon,
+    xywh_from_points,
+    save_image_file
+)
+
+#sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+TOOL = 'ocrd-cis-ocropy-resegment'
+LOG = getLogger('processor.OcropyResegment')
+FILEGRP_IMG = 'OCR-D-IMG-RESEG'
+
+def resegment(line_polygon, region_labels, region_bin, line_id,
+              extend_margins=3,
+              threshold_relative=0.8, threshold_absolute=50):
+    """Reduce polygon in a labelled region to the largest intersection.
+    
+    Given a Numpy array `line_polygon` of relative coordinates
+    in a region given by a Numpy array `region_labels` of numbered
+    segments and a Numpy array `region_bin` of foreground pixels,
+    find the label of the largest segment that intersects the polygon.
+    If the number of foreground pixels within that segment is larger
+    than `threshold_absolute` and if the share of foreground pixels
+    within the whole polygon is larger than `threshold_relative`,
+    then compute the contour of that intersection and return it
+    as a new polygon. Otherwise, return None.
+    
+    If `extend_margins` is larger than zero, then extend `line_polygon`
+    by that amount of pixels horizontally and vertically before.
+    """
+    height, width = region_labels.shape
+    # mask from line polygon:
+    line_mask = np.zeros_like(region_labels)
+    line_mask[draw.polygon(line_polygon[:,1], line_polygon[:,0], line_mask.shape)] = 1
+    # pad line polygon (extend the mask):
+    line_mask = filters.maximum_filter(line_mask, 1 + 2 * extend_margins)
+    # intersect with region labels
+    line_labels = region_labels * line_mask
+    if not np.count_nonzero(line_labels):
+        LOG.warning('Label mask is empty for line "%s"', line_id)
+        return None
+    # find the mask of the largest label (in the foreground):
+    total_count = np.sum(region_bin * line_mask)
+    line_labels_fg = region_bin * line_labels
+    if not np.count_nonzero(line_labels_fg):
+        LOG.warning('No foreground pixels within line mask for line "%s"', line_id)
+        return None
+    label_counts = np.bincount(line_labels_fg.flat)
+    max_label = np.argmax(label_counts[1:]) + 1
+    max_count = label_counts[max_label]
+    if (max_count < threshold_absolute and
+        max_count / total_count < threshold_relative):
+        LOG.info('Largest label (%d) is too small (%d/%d) in line "%s"',
+                 max_label, max_count, total_count, line_id)
+        return None
+    LOG.debug('Black pixels before/after resegment of line "%s" (nlabels=%d): %d/%d',
+              line_id, len(label_counts.nonzero()[0]), total_count, max_count)
+    line_mask = np.array(line_labels == max_label, np.uint8)
+    # measure.find_contours() produces open paths when touching boundaries...
+    # ...how about measure.centroid(line_mask) vs measure.centroid(line_bin)?
+    # convert to polygon outline:
+    contours, _ = cv2.findContours(line_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    # concatenate contour parts (happens with non-contiguous masks due to large hspace):
+    line_polygon = np.vstack(path for path in [
+        # simplify shape:
+        measure.approximate_polygon(contour[:, 0, ::], 2) # already ordered x,y
+        # filter parts with less than 4 points:
+        for contour in contours] if len(path) >= 4)
+    if len(line_polygon) < 4:
+        LOG.warning('found no contour of >=4 points for line "%s"', line_id)
+        return None
+    return line_polygon
+
+class OcropyResegment(Processor):
+
+    def __init__(self, *args, **kwargs):
+        self.ocrd_tool = get_ocrd_tool()
+        kwargs['ocrd_tool'] = self.ocrd_tool['tools'][TOOL]
+        kwargs['version'] = self.ocrd_tool['version']
+        super(OcropyResegment, self).__init__(*args, **kwargs)
+
+    def process(self):
+        """Resegment lines of the workspace.
+        
+        Open and deserialise PAGE input files and their respective images,
+        then iterate over the element hierarchy down to the line level.
+        
+        Next, get each region image according to the layout annotation (from
+        the alternative image of the region, or by cropping via coordinates
+        into the higher-level image), binarize it (without deskewing), and
+        compute a new line segmentation from that (as a label mask).
+        
+        Then for each line within the region, find the label with the largest
+        foreground area in the binarized image within the annotated polygon
+        (or rectangle) of the line. Unless its relative area is too small,
+        or its center is far off, convert that label's mask into a polygon
+        outline, intersect with the old polygon, and find the contour of that
+        segment. Annotate the result as new coordinates of the line.
+        
+        Produce a new output file by serialising the resulting hierarchy.
+        """
+        # This makes best sense for bad/coarse segmentation, like current GT.
+        # Most notably, it can convert rectangles to polygons. It depends on
+        # a decent line segmentation from ocropy though. So it _should_ ideally
+        # be run after deskewing (on the page or region level), and preferably
+        # after binarization (on page or region level), because segmentation of
+        # both a skewed image or of implicit binarization could be suboptimal,
+        # and the explicit binarization after resegmentation could be, too.
+        threshold = self.parameter['min_fraction']
+        margin = self.parameter['extend_margins']
+        
+        for (n, input_file) in enumerate(self.input_files):
+            LOG.info("INPUT FILE %i / %s", n, input_file.pageId or input_file.ID)
+            file_id = input_file.ID.replace(self.input_file_grp, FILEGRP_IMG)
+            if file_id == input_file.ID:
+                file_id = concat_padded(FILEGRP_IMG, n)
+            
+            pcgts = page_from_file(self.workspace.download_file(input_file))
+            page_id = pcgts.pcGtsId or input_file.pageId or input_file.ID # (PageType has no id)
+            page = pcgts.get_Page()
+            page_image = self.workspace.resolve_image_as_pil(page.imageFilename)
+            page_image_info = OcrdExif(page_image)
+            if page_image_info.xResolution != 1:
+                dpi = page_image_info.xResolution
+                if page_image_info.resolutionUnit == 'cm':
+                    dpi = round(dpi * 2.54)
+                LOG.info('Page "%s" uses %d DPI', page_id, dpi)
+                zoom = 300.0/dpi
+            else:
+                zoom = 1
+            page_image, page_xywh = image_from_page(
+                self.workspace, page, page_image, page_id)
+            
+            regions = page.get_TextRegion()
+            if not regions:
+                LOG.warning('Page "%s" contains no text regions', page_id)
+            for region in regions:
+                lines = region.get_TextLine()
+                if not lines:
+                    LOG.warning('Page "%s" region "%s" contains no text lines', page_id, region.id)
+                    continue
+                region_image, region_xywh = image_from_region(
+                    self.workspace, region, page_image, page_xywh)
+                # ad-hoc binarization:
+                region_array = pil2array(region_image)
+                region_array, _ = common.binarize(region_array, maxskew=0) # just in case still raw
+                region_bin = np.array(region_array <= midrange(region_array), np.uint8)
+                try:
+                    region_labels = compute_line_labels(region_array, zoom=zoom)
+                except Exception as err:
+                    LOG.warning('Cannot line-segment page "%s" region "%s": %s',
+                                page_id, region.id, err)
+                    # fallback option 1: borderclean
+                    # label margins vs interior, but with the interior
+                    # extended into the margin by its connected components
+                    # to remove noise from neighbouring regions:
+                    #region_labels = borderclean_bin(region_bin, margin=round(4/zoom)) + 1
+                    # too dangerous, because we risk loosing dots from i or punctuation;
+                    # fallback option2: only extend_margins
+                    # instead, just provide a uniform label, so at least we get
+                    # to extend the polygon margins:
+                    #region_labels = np.ones_like(region_bin)
+                    # fallback option3: keep unchanged
+                    continue
+                for line in lines:
+                    alternative_image = line.get_AlternativeImage()
+                    if alternative_image:
+                        LOG.debug("Using AlternativeImage %d (%s) for line '%s'",
+                                  len(alternative_image), alternative_image[-1].get_comments(),
+                                  line.id)
+                        line_image = workspace.resolve_image_as_pil(
+                            alternative_image[-1].get_filename())
+                        # crop region_labels accordingly:
+                        line_xywh = xywh_from_points(line.get_Coords().points)
+                        line_labels = region_labels[line_xywh['y']-region_xywh['y']:
+                                                    line_xywh['y']-region_xywh['y']+line_xywh['h'],
+                                                    line_xywh['x']-region_xywh['x']:
+                                                    line_xywh['x']-region_xywh['x']+line_xywh['w']]
+                        line_bin = region_bin[line_xywh['y']-region_xywh['y']:
+                                              line_xywh['y']-region_xywh['y']+line_xywh['h'],
+                                              line_xywh['x']-region_xywh['x']:
+                                              line_xywh['x']-region_xywh['x']+line_xywh['w']]
+                        # get polygon in relative (line) coordinates:
+                        line_polygon = coordinates_of_segment(line, line_image, line_xywh)
+                        line_polygon = resegment(line_polygon, line_labels, line_bin, line.id,
+                                                 extend_margins=margin, threshold_relative=threshold)
+                        if line_polygon is None:
+                            continue # not good enough – keep
+                        # convert back to absolute (page) coordinates:
+                        line_polygon = coordinates_for_segment(line_polygon, line_image, line_xywh)
+                    else:
+                        # get polygon in relative (region) coordinates:
+                        line_polygon = coordinates_of_segment(line, region_image, region_xywh)
+                        line_polygon = resegment(line_polygon, region_labels, region_bin, line.id,
+                                                 extend_margins=margin, threshold_relative=threshold)
+                        if line_polygon is None:
+                            continue # not good enough – keep
+                        # convert back to absolute (page) coordinates:
+                        line_polygon = coordinates_for_segment(line_polygon, region_image, region_xywh)
+                    # annotate result:
+                    line.get_Coords().points = points_from_polygon(line_polygon)
+                    # create new image:
+                    line_image, line_xywh = image_from_line(
+                        self.workspace, line, region_image, region_xywh)
+                    # update METS (add the image file):
+                    file_path = save_image_file(
+                        self.workspace,
+                        line_image,
+                        file_id=file_id + '_' + region.id + '_' + line.id,
+                        page_id=page_id,
+                        file_grp=FILEGRP_IMG)
+                    # update PAGE (reference the image file):
+                    line.add_AlternativeImage(AlternativeImageType(
+                        filename=file_path,
+                        comments=('cropped,clipped')))
+            
+            # update METS (add the PAGE file):
+            file_id = input_file.ID.replace(self.input_file_grp,
+                                            self.output_file_grp)
+            if file_id == input_file.ID:
+                file_id = concat_padded(self.output_file_grp, n)
+            file_path = os.path.join(self.output_file_grp,
+                                     file_id + '.xml')
+            out = self.workspace.add_file(
+                ID=file_id,
+                file_grp=self.output_file_grp,
+                pageId=input_file.pageId,
+                local_filename=file_path,
+                mimetype=MIMETYPE_PAGE,
+                content=to_xml(pcgts))
+            LOG.info('created file ID: %s, file_grp: %s, path: %s',
+                     file_id, self.output_file_grp, out.local_filename)
+    

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 Installs:
     - ocrd-cis-align
     - ocrd-cis-profile
-    - ocrd-cis-ocropy-binarize
+    - ocrd-cis-ocropy-clip
     - ocrd-cis-ocropy-deskew
+    - ocrd-cis-ocropy-binarize
+    - ocrd-cis-ocropy-resegment
     - ocrd-cis-ocropy-dewarp
     - ocrd-cis-ocropy-recognize
     - ocrd-cis-ocropy-train
@@ -45,10 +47,12 @@ setup(
             'ocrd-cis-align=ocrd_cis.align.cli:cis_ocrd_align',
             'ocrd-cis-profile=ocrd_cis.profile.cli:cis_ocrd_profile',
             'ocrd-cis-ocropy-binarize=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_binarize',
+            'ocrd-cis-ocropy-clip=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_clip',
             'ocrd-cis-ocropy-deskew=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_deskew',
             'ocrd-cis-ocropy-dewarp=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_dewarp',
             'ocrd-cis-ocropy-recognize=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_recognize',
             'ocrd-cis-ocropy-rec=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_rec',
+            'ocrd-cis-ocropy-resegment=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_resegment',
             'ocrd-cis-ocropy-train=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_train',
             'ocrd-cis-aio=ocrd_cis.aio.cli:cis_ocrd_aio',
             'ocrd-cis-stats=ocrd_cis.div.cli:cis_ocrd_stats',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 Installs:
     - ocrd-cis-align
     - ocrd-cis-profile
+    - ocrd-cis-ocropy-binarize
+    - ocrd-cis-ocropy-deskew
+    - ocrd-cis-ocropy-dewarp
     - ocrd-cis-ocropy-recognize
     - ocrd-cis-ocropy-train
     - ocrd-cis-aio
@@ -17,7 +20,7 @@ from setuptools import find_packages
 
 setup(
     name='cis-ocrd',
-    version='0.0.2',
+    version='0.0.3',
     description='description',
     long_description='long description',
     author='Florian Fink, Tobias Englmeier, Christoph Weber',
@@ -41,6 +44,9 @@ setup(
         'console_scripts': [
             'ocrd-cis-align=ocrd_cis.align.cli:cis_ocrd_align',
             'ocrd-cis-profile=ocrd_cis.profile.cli:cis_ocrd_profile',
+            'ocrd-cis-ocropy-binarize=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_binarize',
+            'ocrd-cis-ocropy-deskew=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_deskew',
+            'ocrd-cis-ocropy-dewarp=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_dewarp',
             'ocrd-cis-ocropy-recognize=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_recognize',
             'ocrd-cis-ocropy-rec=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_rec',
             'ocrd-cis-ocropy-train=ocrd_cis.ocropy.cli:cis_ocrd_ocropy_train',


### PR DESCRIPTION
details see changelog, roughly:

- extra processors for binarization, deskewing, dewarping with ocropy
- pipeline relies on `AlternativeImage` – as reference implementation showing how to deal with relative coordinates and coordinate transforms (rotation, translation, offset)
- use variant of ocropy page segmentation to re-segment region rectangles into line masks
- extra module for common ocropy functions 

I will provide more examples and images shortly.